### PR TITLE
Support parsing PL/pgSQL function definitions

### DIFF
--- a/ext/pg_query/pg_plpgsql_comp.c
+++ b/ext/pg_query/pg_plpgsql_comp.c
@@ -1,0 +1,661 @@
+#include "plpgsql.h"
+
+#include "catalog/pg_proc_fn.h"
+#include "catalog/pg_type.h"
+#include "utils/builtins.h"
+#include "utils/guc.h"
+#include "utils/memutils.h"
+
+/* ----------
+ * Our own local and global variables
+ * ----------
+ */
+PLpgSQL_stmt_block *plpgsql_parse_result;
+
+static int	datums_alloc;
+int			plpgsql_nDatums;
+PLpgSQL_datum **plpgsql_Datums;
+static int	datums_last = 0;
+
+char	   *plpgsql_error_funcname;
+bool		plpgsql_DumpExecTree = false;
+bool		plpgsql_check_syntax = false;
+
+PLpgSQL_function *plpgsql_curr_compile;
+
+/* A context appropriate for short-term allocs during compilation */
+MemoryContext compile_tmp_cxt;
+
+static void plpgsql_compile_error_callback(void *arg);
+static void add_dummy_return(PLpgSQL_function *function);
+static PLpgSQL_type *build_dummy_datatype(char *ident);
+static PLpgSQL_row *build_row_from_class(Oid classOid);
+
+
+/* ----------
+ * plpgsql_compile_inline	Make an execution tree for an anonymous code block.
+ *
+ * Note: this is generally parallel to do_compile(); is it worth trying to
+ * merge the two?
+ *
+ * Note: we assume the block will be thrown away so there is no need to build
+ * persistent data structures.
+ * ----------
+ */
+PLpgSQL_function *
+plpgsql_compile_inline(char *proc_source)
+{
+	char	   *func_name = "inline_code_block";
+	PLpgSQL_function *function;
+	ErrorContextCallback plerrcontext;
+	PLpgSQL_variable *var;
+	int			parse_rc;
+	MemoryContext func_cxt;
+	int			i;
+
+	/*
+	 * Setup the scanner input and error info.  We assume that this function
+	 * cannot be invoked recursively, so there's no need to save and restore
+	 * the static variables used here.
+	 */
+	plpgsql_scanner_init(proc_source);
+
+	plpgsql_error_funcname = func_name;
+
+	/*
+	 * Setup error traceback support for ereport()
+	 */
+	plerrcontext.callback = plpgsql_compile_error_callback;
+	plerrcontext.arg = proc_source;
+	plerrcontext.previous = error_context_stack;
+	error_context_stack = &plerrcontext;
+
+	/* Do extra syntax checking if check_function_bodies is on */
+	plpgsql_check_syntax = check_function_bodies;
+
+	/* Function struct does not live past current statement */
+	function = (PLpgSQL_function *) palloc0(sizeof(PLpgSQL_function));
+
+	plpgsql_curr_compile = function;
+
+	/*
+	 * All the rest of the compile-time storage (e.g. parse tree) is kept in
+	 * its own memory context, so it can be reclaimed easily.
+	 */
+	func_cxt = AllocSetContextCreate(CurrentMemoryContext,
+									 "PL/pgSQL function context",
+									 ALLOCSET_DEFAULT_MINSIZE,
+									 ALLOCSET_DEFAULT_INITSIZE,
+									 ALLOCSET_DEFAULT_MAXSIZE);
+	compile_tmp_cxt = MemoryContextSwitchTo(func_cxt);
+
+	function->fn_signature = pstrdup(func_name);
+	function->fn_is_trigger = PLPGSQL_NOT_TRIGGER;
+	function->fn_input_collation = InvalidOid;
+	function->fn_cxt = func_cxt;
+	function->out_param_varno = -1;		/* set up for no OUT param */
+	function->resolve_option = plpgsql_variable_conflict;
+	function->print_strict_params = plpgsql_print_strict_params;
+
+	/*
+	 * don't do extra validation for inline code as we don't want to add spam
+	 * at runtime
+	 */
+	function->extra_warnings = 0;
+	function->extra_errors = 0;
+
+	plpgsql_ns_init();
+	plpgsql_ns_push(func_name);
+	plpgsql_DumpExecTree = false;
+
+	datums_alloc = 128;
+	plpgsql_nDatums = 0;
+	plpgsql_Datums = palloc(sizeof(PLpgSQL_datum *) * datums_alloc);
+	datums_last = 0;
+
+	/* Set up as though in a function returning VOID */
+	function->fn_rettype = VOIDOID;
+	function->fn_retset = false;
+	function->fn_retistuple = false;
+	/* a bit of hardwired knowledge about type VOID here */
+	function->fn_retbyval = true;
+	function->fn_rettyplen = sizeof(int32);
+
+	/*
+	 * Remember if function is STABLE/IMMUTABLE.  XXX would it be better to
+	 * set this TRUE inside a read-only transaction?  Not clear.
+	 */
+	function->fn_readonly = false;
+
+	/*
+	 * Create the magic FOUND variable.
+	 */
+	var = plpgsql_build_variable("found", 0,
+								 plpgsql_build_datatype(BOOLOID,
+														-1,
+														InvalidOid),
+								 true);
+	function->found_varno = var->dno;
+
+	/*
+	 * Now parse the function's text
+	 */
+	parse_rc = plpgsql_yyparse();
+	if (parse_rc != 0)
+		elog(ERROR, "plpgsql parser returned %d", parse_rc);
+	function->action = plpgsql_parse_result;
+
+	plpgsql_scanner_finish();
+
+	/*
+	 * If it returns VOID (always true at the moment), we allow control to
+	 * fall off the end without an explicit RETURN statement.
+	 */
+	if (function->fn_rettype == VOIDOID)
+		add_dummy_return(function);
+
+	/*
+	 * Complete the function's info
+	 */
+	function->fn_nargs = 0;
+	function->ndatums = plpgsql_nDatums;
+	function->datums = palloc(sizeof(PLpgSQL_datum *) * plpgsql_nDatums);
+	for (i = 0; i < plpgsql_nDatums; i++)
+		function->datums[i] = plpgsql_Datums[i];
+
+	/*
+	 * Pop the error context stack
+	 */
+	error_context_stack = plerrcontext.previous;
+	plpgsql_error_funcname = NULL;
+
+	plpgsql_check_syntax = false;
+
+	MemoryContextSwitchTo(compile_tmp_cxt);
+	compile_tmp_cxt = NULL;
+	return function;
+}
+
+/*
+ * error context callback to let us supply a call-stack traceback.
+ * If we are validating or executing an anonymous code block, the function
+ * source text is passed as an argument.
+ */
+static void
+plpgsql_compile_error_callback(void *arg)
+{
+	if (arg)
+	{
+		/*
+		 * Try to convert syntax error position to reference text of original
+		 * CREATE FUNCTION or DO command.
+		 */
+		if (function_parse_error_transpose((const char *) arg))
+			return;
+
+		/*
+		 * Done if a syntax error position was reported; otherwise we have to
+		 * fall back to a "near line N" report.
+		 */
+	}
+
+	if (plpgsql_error_funcname)
+		errcontext("compilation of PL/pgSQL function \"%s\" near line %d",
+				   plpgsql_error_funcname, plpgsql_latest_lineno());
+}
+
+/*
+ * plpgsql_build_datatype
+ *		Build PLpgSQL_type struct given type OID, typmod, and collation.
+ *
+ * If collation is not InvalidOid then it overrides the type's default
+ * collation.  But collation is ignored if the datatype is non-collatable.
+ */
+PLpgSQL_type *
+plpgsql_build_datatype(Oid typeOid, int32 typmod, Oid collation)
+{
+	return build_dummy_datatype(NULL);
+}
+
+static PLpgSQL_type *
+build_dummy_datatype(char* ident)
+{
+	PLpgSQL_type *typ;
+
+	typ = (PLpgSQL_type *) palloc(sizeof(PLpgSQL_type));
+	typ->ttype = PLPGSQL_TTYPE_SCALAR;
+
+	return typ;
+}
+
+/*
+ * Add a dummy RETURN statement to the given function's body
+ */
+static void
+add_dummy_return(PLpgSQL_function *function)
+{
+	/*
+	 * If the outer block has an EXCEPTION clause, we need to make a new outer
+	 * block, since the added RETURN shouldn't act like it is inside the
+	 * EXCEPTION clause.
+	 */
+	if (function->action->exceptions != NULL)
+	{
+		PLpgSQL_stmt_block *new;
+
+		new = palloc0(sizeof(PLpgSQL_stmt_block));
+		new->cmd_type = PLPGSQL_STMT_BLOCK;
+		new->body = list_make1(function->action);
+
+		function->action = new;
+	}
+	if (function->action->body == NIL ||
+		((PLpgSQL_stmt *) llast(function->action->body))->cmd_type != PLPGSQL_STMT_RETURN)
+	{
+		PLpgSQL_stmt_return *new;
+
+		new = palloc0(sizeof(PLpgSQL_stmt_return));
+		new->cmd_type = PLPGSQL_STMT_RETURN;
+		new->expr = NULL;
+		new->retvarno = function->out_param_varno;
+
+		function->action->body = lappend(function->action->body, new);
+	}
+}
+
+/*
+ * plpgsql_build_variable - build a datum-array entry of a given
+ * datatype
+ *
+ * The returned struct may be a PLpgSQL_var, PLpgSQL_row, or
+ * PLpgSQL_rec depending on the given datatype, and is allocated via
+ * palloc.  The struct is automatically added to the current datum
+ * array, and optionally to the current namespace.
+ */
+PLpgSQL_variable *
+plpgsql_build_variable(const char *refname, int lineno, PLpgSQL_type *dtype,
+					   bool add2namespace)
+{
+	PLpgSQL_variable *result;
+	PLpgSQL_rec *rec;
+
+	rec = plpgsql_build_record(refname, lineno, add2namespace);
+	result = (PLpgSQL_variable *) rec;
+	return result;
+
+	switch (dtype->ttype)
+	{
+		case PLPGSQL_TTYPE_SCALAR:
+			{
+				/* Ordinary scalar datatype */
+				PLpgSQL_var *var;
+
+				var = palloc0(sizeof(PLpgSQL_var));
+				var->dtype = PLPGSQL_DTYPE_VAR;
+				var->refname = pstrdup(refname);
+				var->lineno = lineno;
+				var->datatype = dtype;
+				/* other fields might be filled by caller */
+
+				/* preset to NULL */
+				var->value = 0;
+				var->isnull = true;
+				var->freeval = false;
+
+				plpgsql_adddatum((PLpgSQL_datum *) var);
+				if (add2namespace)
+					plpgsql_ns_additem(PLPGSQL_NSTYPE_VAR,
+									   var->dno,
+									   refname);
+				result = (PLpgSQL_variable *) var;
+				break;
+			}
+		case PLPGSQL_TTYPE_ROW:
+			{
+				/* Composite type -- build a row variable */
+				PLpgSQL_row *row;
+
+				row = build_row_from_class(dtype->typrelid);
+
+				row->dtype = PLPGSQL_DTYPE_ROW;
+				row->refname = pstrdup(refname);
+				row->lineno = lineno;
+
+				plpgsql_adddatum((PLpgSQL_datum *) row);
+				if (add2namespace)
+					plpgsql_ns_additem(PLPGSQL_NSTYPE_ROW,
+									   row->dno,
+									   refname);
+				result = (PLpgSQL_variable *) row;
+				break;
+			}
+		case PLPGSQL_TTYPE_REC:
+			{
+				/* "record" type -- build a record variable */
+				PLpgSQL_rec *rec;
+
+				rec = plpgsql_build_record(refname, lineno, add2namespace);
+				result = (PLpgSQL_variable *) rec;
+				break;
+			}
+		case PLPGSQL_TTYPE_PSEUDO:
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("variable \"%s\" has pseudo-type %s",
+							refname, format_type_be(dtype->typoid))));
+			result = NULL;		/* keep compiler quiet */
+			break;
+		default:
+			elog(ERROR, "unrecognized ttype: %d", dtype->ttype);
+			result = NULL;		/* keep compiler quiet */
+			break;
+	}
+
+	return result;
+}
+
+
+/*
+ * Build empty named record variable, and optionally add it to namespace
+ */
+PLpgSQL_rec *
+plpgsql_build_record(const char *refname, int lineno, bool add2namespace)
+{
+	PLpgSQL_rec *rec;
+
+	rec = palloc0(sizeof(PLpgSQL_rec));
+	rec->dtype = PLPGSQL_DTYPE_REC;
+	rec->refname = pstrdup(refname);
+	rec->lineno = lineno;
+	rec->tup = NULL;
+	rec->tupdesc = NULL;
+	rec->freetup = false;
+	plpgsql_adddatum((PLpgSQL_datum *) rec);
+	if (add2namespace)
+		plpgsql_ns_additem(PLPGSQL_NSTYPE_REC, rec->dno, rec->refname);
+
+	return rec;
+}
+
+/* ----------
+ * plpgsql_adddatum			Add a variable, record or row
+ *					to the compiler's datum list.
+ * ----------
+ */
+void
+plpgsql_adddatum(PLpgSQL_datum *new)
+{
+	if (plpgsql_nDatums == datums_alloc)
+	{
+		datums_alloc *= 2;
+		plpgsql_Datums = repalloc(plpgsql_Datums, sizeof(PLpgSQL_datum *) * datums_alloc);
+	}
+
+	new->dno = plpgsql_nDatums;
+	plpgsql_Datums[plpgsql_nDatums++] = new;
+}
+
+/* ----------
+ * plpgsql_add_initdatums		Make an array of the datum numbers of
+ *					all the simple VAR datums created since the last call
+ *					to this function.
+ *
+ * If varnos is NULL, we just forget any datum entries created since the
+ * last call.
+ *
+ * This is used around a DECLARE section to create a list of the VARs
+ * that have to be initialized at block entry.  Note that VARs can also
+ * be created elsewhere than DECLARE, eg by a FOR-loop, but it is then
+ * the responsibility of special-purpose code to initialize them.
+ * ----------
+ */
+int
+plpgsql_add_initdatums(int **varnos)
+{
+	int			i;
+	int			n = 0;
+
+	for (i = datums_last; i < plpgsql_nDatums; i++)
+	{
+		switch (plpgsql_Datums[i]->dtype)
+		{
+			case PLPGSQL_DTYPE_VAR:
+				n++;
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	if (varnos != NULL)
+	{
+		if (n > 0)
+		{
+			*varnos = (int *) palloc(sizeof(int) * n);
+
+			n = 0;
+			for (i = datums_last; i < plpgsql_nDatums; i++)
+			{
+				switch (plpgsql_Datums[i]->dtype)
+				{
+					case PLPGSQL_DTYPE_VAR:
+						(*varnos)[n++] = plpgsql_Datums[i]->dno;
+
+					default:
+						break;
+				}
+			}
+		}
+		else
+			*varnos = NULL;
+	}
+
+	datums_last = plpgsql_nDatums;
+	return n;
+}
+
+/* ----------
+ * plpgsql_parse_word		The scanner calls this to postparse
+ *				any single word that is not a reserved keyword.
+ *
+ * word1 is the downcased/dequoted identifier; it must be palloc'd in the
+ * function's long-term memory context.
+ *
+ * yytxt is the original token text; we need this to check for quoting,
+ * so that later checks for unreserved keywords work properly.
+ *
+ * If recognized as a variable, fill in *wdatum and return TRUE;
+ * if not recognized, fill in *word and return FALSE.
+ * (Note: those two pointers actually point to members of the same union,
+ * but for notational reasons we pass them separately.)
+ * ----------
+ */
+bool
+plpgsql_parse_word(char *word1, const char *yytxt,
+				   PLwdatum *wdatum, PLword *word)
+{
+	PLpgSQL_nsitem *ns;
+
+	/*
+	 * We should do nothing in DECLARE sections.  In SQL expressions, there's
+	 * no need to do anything either --- lookup will happen when the
+	 * expression is compiled.
+	 */
+	if (plpgsql_IdentifierLookup == IDENTIFIER_LOOKUP_NORMAL)
+	{
+		/*
+		 * Do a lookup in the current namespace stack
+		 */
+		ns = plpgsql_ns_lookup(plpgsql_ns_top(), false,
+							   word1, NULL, NULL,
+							   NULL);
+
+		if (ns != NULL)
+		{
+			switch (ns->itemtype)
+			{
+				case PLPGSQL_NSTYPE_VAR:
+				case PLPGSQL_NSTYPE_ROW:
+				case PLPGSQL_NSTYPE_REC:
+					wdatum->datum = plpgsql_Datums[ns->itemno];
+					wdatum->ident = word1;
+					wdatum->quoted = (yytxt[0] == '"');
+					wdatum->idents = NIL;
+					return true;
+
+				default:
+					/* plpgsql_ns_lookup should never return anything else */
+					elog(ERROR, "unrecognized plpgsql itemtype: %d",
+						 ns->itemtype);
+			}
+		}
+	}
+
+	/*
+	 * Nothing found - up to now it's a word without any special meaning for
+	 * us.
+	 */
+	word->ident = word1;
+	word->quoted = (yytxt[0] == '"');
+	return false;
+}
+
+/* ----------
+ * plpgsql_parse_wordrowtype		Scanner found word%ROWTYPE.
+ *					So word must be a table name.
+ * ----------
+ */
+PLpgSQL_type *
+plpgsql_parse_wordrowtype(char *ident)
+{
+	return build_dummy_datatype(ident);
+}
+
+/* ----------
+ * plpgsql_parse_dblword		Same lookup for two words
+ *					separated by a dot.
+ * ----------
+ */
+bool
+plpgsql_parse_dblword(char *word1, char *word2,
+					  PLwdatum *wdatum, PLcword *cword)
+{
+	PLpgSQL_nsitem *ns;
+	List	   *idents;
+	int			nnames;
+
+	idents = list_make2(makeString(word1),
+						makeString(word2));
+
+	/*
+	 * We should do nothing in DECLARE sections.  In SQL expressions, we
+	 * really only need to make sure that RECFIELD datums are created when
+	 * needed.
+	 */
+	if (plpgsql_IdentifierLookup != IDENTIFIER_LOOKUP_DECLARE)
+	{
+		/*
+		 * Do a lookup in the current namespace stack
+		 */
+		ns = plpgsql_ns_lookup(plpgsql_ns_top(), false,
+							   word1, word2, NULL,
+							   &nnames);
+		if (ns != NULL)
+		{
+			switch (ns->itemtype)
+			{
+				case PLPGSQL_NSTYPE_VAR:
+					/* Block-qualified reference to scalar variable. */
+					wdatum->datum = plpgsql_Datums[ns->itemno];
+					wdatum->ident = NULL;
+					wdatum->quoted = false;		/* not used */
+					wdatum->idents = idents;
+					return true;
+
+				case PLPGSQL_NSTYPE_REC:
+					if (nnames == 1)
+					{
+						/*
+						 * First word is a record name, so second word could
+						 * be a field in this record.  We build a RECFIELD
+						 * datum whether it is or not --- any error will be
+						 * detected later.
+						 */
+						PLpgSQL_recfield *new;
+
+						new = palloc(sizeof(PLpgSQL_recfield));
+						new->dtype = PLPGSQL_DTYPE_RECFIELD;
+						new->fieldname = pstrdup(word2);
+						new->recparentno = ns->itemno;
+
+						plpgsql_adddatum((PLpgSQL_datum *) new);
+
+						wdatum->datum = (PLpgSQL_datum *) new;
+					}
+					else
+					{
+						/* Block-qualified reference to record variable. */
+						wdatum->datum = plpgsql_Datums[ns->itemno];
+					}
+					wdatum->ident = NULL;
+					wdatum->quoted = false;		/* not used */
+					wdatum->idents = idents;
+					return true;
+
+				case PLPGSQL_NSTYPE_ROW:
+					if (nnames == 1)
+					{
+						/*
+						 * First word is a row name, so second word could be a
+						 * field in this row.  Again, no error now if it
+						 * isn't.
+						 */
+						PLpgSQL_row *row;
+						int			i;
+
+						row = (PLpgSQL_row *) (plpgsql_Datums[ns->itemno]);
+						for (i = 0; i < row->nfields; i++)
+						{
+							if (row->fieldnames[i] &&
+								strcmp(row->fieldnames[i], word2) == 0)
+							{
+								wdatum->datum = plpgsql_Datums[row->varnos[i]];
+								wdatum->ident = NULL;
+								wdatum->quoted = false; /* not used */
+								wdatum->idents = idents;
+								return true;
+							}
+						}
+						/* fall through to return CWORD */
+					}
+					else
+					{
+						/* Block-qualified reference to row variable. */
+						wdatum->datum = plpgsql_Datums[ns->itemno];
+						wdatum->ident = NULL;
+						wdatum->quoted = false; /* not used */
+						wdatum->idents = idents;
+						return true;
+					}
+					break;
+
+				default:
+					break;
+			}
+		}
+	}
+
+	/* Nothing found */
+	cword->idents = idents;
+	return false;
+}
+
+/*
+ * Build a row-variable data structure given the pg_class OID.
+ */
+static PLpgSQL_row *
+build_row_from_class(Oid classOid)
+{
+	return NULL;
+}

--- a/ext/pg_query/pg_plpgsql_to_json.c
+++ b/ext/pg_query/pg_plpgsql_to_json.c
@@ -1,0 +1,846 @@
+#include "pg_query.h"
+#include "pg_plpgsql_to_json.h"
+
+#include "lib/stringinfo.h"
+
+#define WRITE_INT_FIELD(fldname, value) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": %d, ", value)
+
+#define WRITE_UINT_FIELD(fldname, value) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": %u, ", value)
+
+/* Write an OID field (don't hard-wire assumption that OID is same as uint) */
+#define WRITE_OID_FIELD(fldname, value) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": %u, ", value)
+
+#define WRITE_LONG_FIELD(fldname, value) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": %ld, ", value)
+
+/* Write a char field (ie, one ascii character) */
+#define WRITE_CHAR_FIELD(fldname, value) \
+  if (node->fldname == 0) { appendStringInfo(str, "\"" CppAsString(fldname) "\": null, "); \
+  } else { appendStringInfo(str, "\"" CppAsString(fldname) "\": \"%c\", ", value); }
+
+/* Write an enumerated-type field as an integer code */
+#define WRITE_ENUM_FIELD(fldname, value) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": %d, ", \
+					 (int) value)
+
+/* Write a float field --- caller must give format to define precision */
+#define WRITE_FLOAT_FIELD(fldname, format, value) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": " format ", ", value)
+
+/* Write a boolean field */
+#define WRITE_BOOL_FIELD(fldname, value) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": %s, ", \
+					 booltostr(value))
+
+/* Write a character-string (possibly NULL) field */
+#define WRITE_STRING_FIELD(fldname, value) \
+	(appendStringInfo(str, "\"" CppAsString(fldname) "\": "), \
+	 _outToken(str, value), \
+	 appendStringInfo(str, ", "))
+
+#define WRITE_NULL_FIELD(fldname) \
+	appendStringInfo(str, "\"" CppAsString(fldname) "\": null, ")
+
+#define booltostr(x)  ((x) ? "true" : "false")
+
+/*
+* _outToken
+*	  Convert an ordinary string (eg, an identifier) into a form that
+*	  will be decoded back to a plain token by read.c's functions.
+*
+*	  If a null or empty string is given, it is encoded as "<>".
+*/
+static void
+_outToken(StringInfo str, const char *s)
+{
+	if (s == NULL || *s == '\0')
+	{
+		appendStringInfoString(str, "null");
+		return;
+	}
+
+	appendStringInfoChar(str, '"');
+	while (*s)
+	{
+		/* These chars must be backslashed anywhere in the string */
+		if (*s == '\n')
+			appendStringInfoString(str, "\\n");
+		else if (*s == '\r')
+			appendStringInfoString(str, "\\r");
+		else if (*s == '\t')
+			appendStringInfoString(str, "\\t");
+		else if (*s == '\\' || *s == '"') {
+			appendStringInfoChar(str, '\\');
+			appendStringInfoChar(str, *s);
+		} else
+			appendStringInfoChar(str, *s);
+		s++;
+	}
+	appendStringInfoChar(str, '"');
+}
+
+static void
+removeTrailingDelimiter(StringInfo str)
+{
+	if (str->len >= 2 && str->data[str->len - 2] == ',' && str->data[str->len - 1] == ' ') {
+		str->len -= 2;
+		str->data[str->len] = '\0';
+	} else if (str->len >= 1 && str->data[str->len - 1] == ',') {
+		str->len -= 1;
+		str->data[str->len] = '\0';
+	}
+}
+
+static void dump_stmt(StringInfo str, PLpgSQL_stmt *stmt);
+static void dump_block(StringInfo str, PLpgSQL_stmt_block *block);
+static void dump_assign(StringInfo str, PLpgSQL_stmt_assign *stmt);
+static void dump_if(StringInfo str, PLpgSQL_stmt_if *stmt);
+static void dump_case(StringInfo str, PLpgSQL_stmt_case *stmt);
+static void dump_loop(StringInfo str, PLpgSQL_stmt_loop *stmt);
+static void dump_while(StringInfo str, PLpgSQL_stmt_while *stmt);
+static void dump_fori(StringInfo str, PLpgSQL_stmt_fori *stmt);
+static void dump_fors(StringInfo str, PLpgSQL_stmt_fors *stmt);
+static void dump_forc(StringInfo str, PLpgSQL_stmt_forc *stmt);
+static void dump_foreach_a(StringInfo str, PLpgSQL_stmt_foreach_a *stmt);
+static void dump_exit(StringInfo str, PLpgSQL_stmt_exit *stmt);
+static void dump_return(StringInfo str, PLpgSQL_stmt_return *stmt);
+static void dump_return_next(StringInfo str, PLpgSQL_stmt_return_next *stmt);
+static void dump_return_query(StringInfo str, PLpgSQL_stmt_return_query *stmt);
+static void dump_raise(StringInfo str, PLpgSQL_stmt_raise *stmt);
+static void dump_execsql(StringInfo str, PLpgSQL_stmt_execsql *stmt);
+static void dump_dynexecute(StringInfo str, PLpgSQL_stmt_dynexecute *stmt);
+static void dump_dynfors(StringInfo str, PLpgSQL_stmt_dynfors *stmt);
+static void dump_getdiag(StringInfo str, PLpgSQL_stmt_getdiag *stmt);
+static void dump_open(StringInfo str, PLpgSQL_stmt_open *stmt);
+static void dump_fetch(StringInfo str, PLpgSQL_stmt_fetch *stmt);
+static void dump_cursor_direction(StringInfo str, PLpgSQL_stmt_fetch *stmt);
+static void dump_close(StringInfo str, PLpgSQL_stmt_close *stmt);
+static void dump_perform(StringInfo str, PLpgSQL_stmt_perform *stmt);
+static void dump_expr(StringInfo str, PLpgSQL_expr *expr);
+static void dump_function(StringInfo str, PLpgSQL_function *func);
+
+static void
+dump_stmt(StringInfo str, PLpgSQL_stmt *stmt)
+{
+
+	appendStringInfoChar(str, '{');
+	WRITE_INT_FIELD(lineno, stmt->lineno);
+	switch ((enum PLpgSQL_stmt_types) stmt->cmd_type)
+	{
+		case PLPGSQL_STMT_BLOCK:
+			dump_block(str, (PLpgSQL_stmt_block *) stmt);
+			break;
+		case PLPGSQL_STMT_ASSIGN:
+			dump_assign(str, (PLpgSQL_stmt_assign *) stmt);
+			break;
+		case PLPGSQL_STMT_IF:
+			dump_if(str, (PLpgSQL_stmt_if *) stmt);
+			break;
+		case PLPGSQL_STMT_CASE:
+			dump_case(str, (PLpgSQL_stmt_case *) stmt);
+			break;
+		case PLPGSQL_STMT_LOOP:
+			dump_loop(str, (PLpgSQL_stmt_loop *) stmt);
+			break;
+		case PLPGSQL_STMT_WHILE:
+			dump_while(str, (PLpgSQL_stmt_while *) stmt);
+			break;
+		case PLPGSQL_STMT_FORI:
+			dump_fori(str, (PLpgSQL_stmt_fori *) stmt);
+			break;
+		case PLPGSQL_STMT_FORS:
+			dump_fors(str, (PLpgSQL_stmt_fors *) stmt);
+			break;
+		case PLPGSQL_STMT_FORC:
+			dump_forc(str, (PLpgSQL_stmt_forc *) stmt);
+			break;
+		case PLPGSQL_STMT_FOREACH_A:
+			dump_foreach_a(str, (PLpgSQL_stmt_foreach_a *) stmt);
+			break;
+		case PLPGSQL_STMT_EXIT:
+			dump_exit(str, (PLpgSQL_stmt_exit *) stmt);
+			break;
+		case PLPGSQL_STMT_RETURN:
+			dump_return(str, (PLpgSQL_stmt_return *) stmt);
+			break;
+		case PLPGSQL_STMT_RETURN_NEXT:
+			dump_return_next(str, (PLpgSQL_stmt_return_next *) stmt);
+			break;
+		case PLPGSQL_STMT_RETURN_QUERY:
+			dump_return_query(str, (PLpgSQL_stmt_return_query *) stmt);
+			break;
+		case PLPGSQL_STMT_RAISE:
+			dump_raise(str, (PLpgSQL_stmt_raise *) stmt);
+			break;
+		case PLPGSQL_STMT_EXECSQL:
+			dump_execsql(str, (PLpgSQL_stmt_execsql *) stmt);
+			break;
+		case PLPGSQL_STMT_DYNEXECUTE:
+			dump_dynexecute(str, (PLpgSQL_stmt_dynexecute *) stmt);
+			break;
+		case PLPGSQL_STMT_DYNFORS:
+			dump_dynfors(str, (PLpgSQL_stmt_dynfors *) stmt);
+			break;
+		case PLPGSQL_STMT_GETDIAG:
+			dump_getdiag(str, (PLpgSQL_stmt_getdiag *) stmt);
+			break;
+		case PLPGSQL_STMT_OPEN:
+			dump_open(str, (PLpgSQL_stmt_open *) stmt);
+			break;
+		case PLPGSQL_STMT_FETCH:
+			dump_fetch(str, (PLpgSQL_stmt_fetch *) stmt);
+			break;
+		case PLPGSQL_STMT_CLOSE:
+			dump_close(str, (PLpgSQL_stmt_close *) stmt);
+			break;
+		case PLPGSQL_STMT_PERFORM:
+			dump_perform(str, (PLpgSQL_stmt_perform *) stmt);
+			break;
+		default:
+			elog(ERROR, "unrecognized cmd_type: %d", stmt->cmd_type);
+			break;
+	}
+	removeTrailingDelimiter(str);
+	appendStringInfoString(str, "}, ");
+}
+
+static void
+dump_stmts(StringInfo str, List *stmts)
+{
+	ListCell   *s;
+
+	appendStringInfoString(str, "\"statements\": ");
+	appendStringInfoChar(str, '[');
+	foreach(s, stmts) {
+		dump_stmt(str, (PLpgSQL_stmt *) lfirst(s));
+	}
+	removeTrailingDelimiter(str);
+	appendStringInfoString(str, "], ");
+}
+
+static void
+dump_block(StringInfo str, PLpgSQL_stmt_block *block)
+{
+	char	   *name;
+
+	if (block->label == NULL)
+		name = "*unnamed*";
+	else
+		name = block->label;
+
+  WRITE_STRING_FIELD(type, "block");
+  WRITE_STRING_FIELD(name, name);
+
+	dump_stmts(str, block->body);
+
+	if (block->exceptions)
+	{
+		ListCell   *e;
+
+		foreach(e, block->exceptions->exc_list)
+		{
+			PLpgSQL_exception *exc = (PLpgSQL_exception *) lfirst(e);
+			PLpgSQL_condition *cond;
+
+			appendStringInfo(str, "    EXCEPTION WHEN ");
+			for (cond = exc->conditions; cond; cond = cond->next)
+			{
+				if (cond != exc->conditions)
+					appendStringInfo(str, " OR ");
+				appendStringInfo(str, "%s", cond->condname);
+			}
+			appendStringInfo(str, " THEN");
+			dump_stmts(str, exc->action);
+		}
+	}
+
+	removeTrailingDelimiter(str);
+}
+
+static void
+dump_assign(StringInfo str, PLpgSQL_stmt_assign *stmt)
+{
+	WRITE_STRING_FIELD(type, "ASSIGN");
+	WRITE_INT_FIELD(varno, stmt->varno);
+	dump_expr(str, stmt->expr);
+}
+
+static void
+dump_if(StringInfo str, PLpgSQL_stmt_if *stmt)
+{
+	ListCell   *l;
+
+	appendStringInfo(str, "IF ");
+	dump_expr(str, stmt->cond);
+	appendStringInfo(str, " THEN");
+	dump_stmts(str, stmt->then_body);
+	foreach(l, stmt->elsif_list)
+	{
+		PLpgSQL_if_elsif *elif = (PLpgSQL_if_elsif *) lfirst(l);
+
+		appendStringInfo(str, "    ELSIF ");
+		dump_expr(str, elif->cond);
+		appendStringInfo(str, " THEN");
+		dump_stmts(str, elif->stmts);
+	}
+	if (stmt->else_body != NIL)
+	{
+		appendStringInfo(str, "    ELSE");
+		dump_stmts(str, stmt->else_body);
+	}
+	appendStringInfo(str, "    ENDIF");
+}
+
+static void
+dump_case(StringInfo str, PLpgSQL_stmt_case *stmt)
+{
+	ListCell   *l;
+
+	WRITE_STRING_FIELD(type, "CASE");
+	WRITE_INT_FIELD(varno, stmt->t_varno);
+	if (stmt->t_expr)
+		dump_expr(str, stmt->t_expr);
+	foreach(l, stmt->case_when_list)
+	{
+		PLpgSQL_case_when *cwt = (PLpgSQL_case_when *) lfirst(l);
+
+		appendStringInfo(str, "WHEN ");
+		dump_expr(str, cwt->expr);
+		appendStringInfo(str, "THEN");
+		dump_stmts(str, cwt->stmts);
+	}
+	if (stmt->have_else)
+	{
+		appendStringInfo(str, "ELSE");
+		dump_stmts(str, stmt->else_stmts);
+	}
+}
+
+static void
+dump_loop(StringInfo str, PLpgSQL_stmt_loop *stmt)
+{
+	WRITE_STRING_FIELD(type, "LOOP");
+	dump_stmts(str, stmt->body);
+}
+
+static void
+dump_while(StringInfo str, PLpgSQL_stmt_while *stmt)
+{
+	WRITE_STRING_FIELD(type, "WHILE");
+	dump_expr(str, stmt->cond);
+	dump_stmts(str, stmt->body);
+}
+
+static void
+dump_fori(StringInfo str, PLpgSQL_stmt_fori *stmt)
+{
+	appendStringInfo(str, "FORI %s %s", stmt->var->refname, (stmt->reverse) ? "REVERSE" : "NORMAL");
+
+	appendStringInfo(str, "    lower = ");
+	dump_expr(str, stmt->lower);
+	appendStringInfo(str, "    upper = ");
+	dump_expr(str, stmt->upper);
+	if (stmt->step)
+	{
+		appendStringInfo(str, "    step = ");
+		dump_expr(str, stmt->step);
+	}
+
+	dump_stmts(str, stmt->body);
+
+	appendStringInfo(str, "    ENDFORI");
+}
+
+static void
+dump_fors(StringInfo str, PLpgSQL_stmt_fors *stmt)
+{
+	WRITE_STRING_FIELD(type, "FORS");
+	WRITE_STRING_FIELD(refname, (stmt->rec != NULL) ? stmt->rec->refname : stmt->row->refname);
+
+	dump_expr(str, stmt->query);
+
+	dump_stmts(str, stmt->body);
+}
+
+static void
+dump_forc(StringInfo str, PLpgSQL_stmt_forc *stmt)
+{
+	appendStringInfo(str, "FORC %s ", stmt->rec->refname);
+	appendStringInfo(str, "curvar=%d", stmt->curvar);
+
+	if (stmt->argquery != NULL)
+	{
+		appendStringInfo(str, "  arguments = ");
+		dump_expr(str, stmt->argquery);
+	}
+
+	dump_stmts(str, stmt->body);
+
+	appendStringInfo(str, "    ENDFORC");
+}
+
+static void
+dump_foreach_a(StringInfo str, PLpgSQL_stmt_foreach_a *stmt)
+{
+	appendStringInfo(str, "FOREACHA var %d ", stmt->varno);
+	if (stmt->slice != 0)
+		appendStringInfo(str, "SLICE %d ", stmt->slice);
+	appendStringInfo(str, "IN ");
+	dump_expr(str, stmt->expr);
+
+	dump_stmts(str, stmt->body);
+
+	appendStringInfo(str, "    ENDFOREACHA");
+}
+
+static void
+dump_open(StringInfo str, PLpgSQL_stmt_open *stmt)
+{
+	appendStringInfo(str, "OPEN curvar=%d", stmt->curvar);
+
+	if (stmt->argquery != NULL)
+	{
+		appendStringInfo(str, "  arguments = '");
+		dump_expr(str, stmt->argquery);
+	}
+	if (stmt->query != NULL)
+	{
+		appendStringInfo(str, "  query = '");
+		dump_expr(str, stmt->query);
+	}
+	if (stmt->dynquery != NULL)
+	{
+		appendStringInfo(str, "  execute = '");
+		dump_expr(str, stmt->dynquery);
+
+		if (stmt->params != NIL)
+		{
+			ListCell   *lc;
+			int			i;
+
+			appendStringInfo(str, "    USING");
+			i = 1;
+			foreach(lc, stmt->params)
+			{
+				appendStringInfo(str, "    parameter $%d: ", i++);
+				dump_expr(str, (PLpgSQL_expr *) lfirst(lc));
+			}
+		}
+	}
+}
+
+static void
+dump_fetch(StringInfo str, PLpgSQL_stmt_fetch *stmt)
+{
+	if (!stmt->is_move)
+	{
+		appendStringInfo(str, "FETCH curvar=%d", stmt->curvar);
+		dump_cursor_direction(str, stmt);
+
+		if (stmt->rec != NULL)
+		{
+			appendStringInfo(str, "    target = %d %s", stmt->rec->dno, stmt->rec->refname);
+		}
+		if (stmt->row != NULL)
+		{
+			appendStringInfo(str, "    target = %d %s", stmt->row->dno, stmt->row->refname);
+		}
+	}
+	else
+	{
+		appendStringInfo(str, "MOVE curvar=%d", stmt->curvar);
+		dump_cursor_direction(str, stmt);
+	}
+}
+
+static void
+dump_cursor_direction(StringInfo str, PLpgSQL_stmt_fetch *stmt)
+{
+	switch (stmt->direction)
+	{
+		case FETCH_FORWARD:
+			appendStringInfo(str, "    FORWARD ");
+			break;
+		case FETCH_BACKWARD:
+			appendStringInfo(str, "    BACKWARD ");
+			break;
+		case FETCH_ABSOLUTE:
+			appendStringInfo(str, "    ABSOLUTE ");
+			break;
+		case FETCH_RELATIVE:
+			appendStringInfo(str, "    RELATIVE ");
+			break;
+		default:
+			appendStringInfo(str, "??? unknown cursor direction %d", stmt->direction);
+	}
+
+	if (stmt->expr)
+	{
+		dump_expr(str, stmt->expr);
+	}
+	else
+		appendStringInfo(str, "%ld", stmt->how_many);
+
+}
+
+static void
+dump_close(StringInfo str, PLpgSQL_stmt_close *stmt)
+{
+	appendStringInfo(str, "CLOSE curvar=%d", stmt->curvar);
+}
+
+static void
+dump_perform(StringInfo str, PLpgSQL_stmt_perform *stmt)
+{
+	appendStringInfo(str, "PERFORM expr = ");
+	dump_expr(str, stmt->expr);
+}
+
+static void
+dump_exit(StringInfo str, PLpgSQL_stmt_exit *stmt)
+{
+	appendStringInfo(str, "%s", stmt->is_exit ? "EXIT" : "CONTINUE");
+	if (stmt->label != NULL)
+		appendStringInfo(str, " label='%s'", stmt->label);
+	if (stmt->cond != NULL)
+	{
+		appendStringInfo(str, " WHEN ");
+		dump_expr(str, stmt->cond);
+	}
+}
+
+static void
+dump_return(StringInfo str, PLpgSQL_stmt_return *stmt)
+{
+	WRITE_STRING_FIELD(type, "RETURN");
+
+	if (stmt->retvarno >= 0)
+	  WRITE_UINT_FIELD(variable, stmt->retvarno);
+	else if (stmt->expr != NULL)
+		WRITE_STRING_FIELD(expr, stmt->expr->query);
+	else
+		WRITE_NULL_FIELD(expr);
+
+	removeTrailingDelimiter(str);
+}
+
+static void
+dump_return_next(StringInfo str, PLpgSQL_stmt_return_next *stmt)
+{
+	appendStringInfo(str, "RETURN NEXT ");
+	if (stmt->retvarno >= 0)
+		appendStringInfo(str, "variable %d", stmt->retvarno);
+	else if (stmt->expr != NULL)
+		dump_expr(str, stmt->expr);
+	else
+		appendStringInfo(str, "NULL");
+}
+
+static void
+dump_return_query(StringInfo str, PLpgSQL_stmt_return_query *stmt)
+{
+	if (stmt->query)
+	{
+		appendStringInfo(str, "RETURN QUERY ");
+		dump_expr(str, stmt->query);
+	}
+	else
+	{
+		appendStringInfo(str, "RETURN QUERY EXECUTE ");
+		dump_expr(str, stmt->dynquery);
+		if (stmt->params != NIL)
+		{
+			ListCell   *lc;
+			int			i;
+
+			appendStringInfo(str, "    USING");
+			i = 1;
+			foreach(lc, stmt->params)
+			{
+				appendStringInfo(str, "    parameter $%d: ", i++);
+				dump_expr(str, (PLpgSQL_expr *) lfirst(lc));
+			}
+		}
+	}
+}
+
+static void
+dump_raise(StringInfo str, PLpgSQL_stmt_raise *stmt)
+{
+	ListCell   *lc;
+	int			i = 0;
+
+	appendStringInfo(str, "RAISE level=%d", stmt->elog_level);
+	if (stmt->condname)
+		appendStringInfo(str, " condname='%s'", stmt->condname);
+	if (stmt->message)
+		appendStringInfo(str, " message='%s'", stmt->message);
+	foreach(lc, stmt->params)
+	{
+		appendStringInfo(str, "    parameter %d: ", i++);
+		dump_expr(str, (PLpgSQL_expr *) lfirst(lc));
+	}
+	if (stmt->options)
+	{
+		appendStringInfo(str, "    USING");
+		foreach(lc, stmt->options)
+		{
+			PLpgSQL_raise_option *opt = (PLpgSQL_raise_option *) lfirst(lc);
+
+			switch (opt->opt_type)
+			{
+				case PLPGSQL_RAISEOPTION_ERRCODE:
+					appendStringInfo(str, "    ERRCODE = ");
+					break;
+				case PLPGSQL_RAISEOPTION_MESSAGE:
+					appendStringInfo(str, "    MESSAGE = ");
+					break;
+				case PLPGSQL_RAISEOPTION_DETAIL:
+					appendStringInfo(str, "    DETAIL = ");
+					break;
+				case PLPGSQL_RAISEOPTION_HINT:
+					appendStringInfo(str, "    HINT = ");
+					break;
+				case PLPGSQL_RAISEOPTION_COLUMN:
+					appendStringInfo(str, "    COLUMN = ");
+					break;
+				case PLPGSQL_RAISEOPTION_CONSTRAINT:
+					appendStringInfo(str, "    CONSTRAINT = ");
+					break;
+				case PLPGSQL_RAISEOPTION_DATATYPE:
+					appendStringInfo(str, "    DATATYPE = ");
+					break;
+				case PLPGSQL_RAISEOPTION_TABLE:
+					appendStringInfo(str, "    TABLE = ");
+					break;
+				case PLPGSQL_RAISEOPTION_SCHEMA:
+					appendStringInfo(str, "    SCHEMA = ");
+					break;
+			}
+			dump_expr(str, opt->expr);
+		}
+	}
+}
+
+static void
+dump_execsql(StringInfo str, PLpgSQL_stmt_execsql *stmt)
+{
+	WRITE_STRING_FIELD(type, "EXECSQL");
+	WRITE_STRING_FIELD(query, stmt->sqlstmt->query);
+
+	if (stmt->rec != NULL)
+	{
+		appendStringInfo(str, "    INTO%s target = %d %s",
+			   stmt->strict ? " STRICT" : "",
+			   stmt->rec->dno, stmt->rec->refname);
+	}
+	if (stmt->row != NULL)
+	{
+		appendStringInfo(str, "    INTO%s target = %d %s",
+			   stmt->strict ? " STRICT" : "",
+			   stmt->row->dno, stmt->row->refname);
+	}
+	removeTrailingDelimiter(str);
+}
+
+static void
+dump_dynexecute(StringInfo str, PLpgSQL_stmt_dynexecute *stmt)
+{
+	WRITE_STRING_FIELD(type, "EXECUTE");
+	dump_expr(str, stmt->query);
+
+	WRITE_BOOL_FIELD(strict, stmt->strict);
+	if (stmt->rec != NULL)
+	{
+		WRITE_STRING_FIELD(target, "rec");
+		WRITE_INT_FIELD(target_dno, stmt->rec->dno);
+		WRITE_STRING_FIELD(target_refname, stmt->rec->refname);
+	}
+	if (stmt->row != NULL)
+	{
+		WRITE_STRING_FIELD(target, "row");
+		WRITE_INT_FIELD(target_dno, stmt->row->dno);
+		WRITE_STRING_FIELD(target_refname, stmt->row->refname);
+	}
+	if (stmt->params != NIL)
+	{
+		ListCell   *lc;
+		int			i = 1;
+
+		appendStringInfoString(str, "\"params\": ");
+		appendStringInfoChar(str, '[');
+		foreach(lc, stmt->params)
+		{
+			WRITE_INT_FIELD(paramno, i++);
+			dump_expr(str, (PLpgSQL_expr *) lfirst(lc));
+		}
+		removeTrailingDelimiter(str);
+		appendStringInfoString(str, "], ");
+	}
+}
+
+static void
+dump_dynfors(StringInfo str, PLpgSQL_stmt_dynfors *stmt)
+{
+	appendStringInfo(str, "FORS %s EXECUTE ",
+		   (stmt->rec != NULL) ? stmt->rec->refname : stmt->row->refname);
+	dump_expr(str, stmt->query);
+	if (stmt->params != NIL)
+	{
+		ListCell   *lc;
+		int			i;
+
+		appendStringInfo(str, "    USING");
+		i = 1;
+		foreach(lc, stmt->params)
+		{
+			appendStringInfo(str, "    parameter $%d: ", i++);
+			dump_expr(str, (PLpgSQL_expr *) lfirst(lc));
+		}
+	}
+	dump_stmts(str, stmt->body);
+	appendStringInfo(str, "    ENDFORS");
+}
+
+static void
+dump_getdiag(StringInfo str, PLpgSQL_stmt_getdiag *stmt)
+{
+	ListCell   *lc;
+
+	appendStringInfo(str, "GET %s DIAGNOSTICS ", stmt->is_stacked ? "STACKED" : "CURRENT");
+	foreach(lc, stmt->diag_items)
+	{
+		PLpgSQL_diag_item *diag_item = (PLpgSQL_diag_item *) lfirst(lc);
+
+		if (lc != list_head(stmt->diag_items))
+			appendStringInfo(str, ", ");
+
+		appendStringInfo(str, "{var %d} = %s", diag_item->target,
+			   plpgsql_getdiag_kindname(diag_item->kind));
+	}
+}
+
+static void
+dump_expr(StringInfo str, PLpgSQL_expr *expr)
+{
+	WRITE_STRING_FIELD(expr, expr->query);
+}
+
+static void
+dump_function(StringInfo str, PLpgSQL_function *func)
+{
+	int			i;
+	PLpgSQL_datum *d;
+
+  appendStringInfoChar(str, '{');
+  WRITE_STRING_FIELD(signature, func->fn_signature);
+	appendStringInfoString(str, "\"data_area\": ");
+	appendStringInfoChar(str, '[');
+
+	for (i = 0; i < func->ndatums; i++)
+	{
+	  appendStringInfoChar(str, '{');
+		d = func->datums[i];
+
+		WRITE_INT_FIELD(entry, i);
+		switch (d->dtype)
+		{
+			case PLPGSQL_DTYPE_VAR:
+				{
+					PLpgSQL_var *var = (PLpgSQL_var *) d;
+
+					WRITE_STRING_FIELD(type, "VAR");
+
+					WRITE_STRING_FIELD(refname, var->refname);
+					WRITE_STRING_FIELD(type, var->datatype->typname);
+					WRITE_UINT_FIELD(typoid, var->datatype->typoid);
+					WRITE_INT_FIELD(atttypmod, var->datatype->atttypmod);
+
+					if (var->isconst)
+						appendStringInfo(str, "CONSTANT");
+					if (var->notnull)
+						appendStringInfo(str, "NOT NULL");
+					if (var->default_val != NULL)
+					{
+						appendStringInfo(str, "DEFAULT ");
+						dump_expr(str, var->default_val);
+					}
+					if (var->cursor_explicit_expr != NULL)
+					{
+						if (var->cursor_explicit_argrow >= 0)
+							appendStringInfo(str, "CURSOR argument row %d", var->cursor_explicit_argrow);
+
+						appendStringInfo(str, "CURSOR IS ");
+						dump_expr(str, var->cursor_explicit_expr);
+					}
+				}
+				break;
+			case PLPGSQL_DTYPE_ROW:
+				{
+					PLpgSQL_row *row = (PLpgSQL_row *) d;
+					int			i;
+
+					WRITE_STRING_FIELD(type, "ROW");
+					WRITE_STRING_FIELD(refname, row->refname);
+					appendStringInfoString(str, "\"data_area\": ");
+					appendStringInfoChar(str, '[');
+
+					for (i = 0; i < row->nfields; i++)
+					{
+						if (row->fieldnames[i]) {
+							WRITE_STRING_FIELD(name, row->fieldnames[i]);
+							WRITE_INT_FIELD(varno, row->varnos[i]);
+						}
+					}
+					appendStringInfoString(str, "], ");
+				}
+				break;
+			case PLPGSQL_DTYPE_REC:
+				WRITE_STRING_FIELD(type, "REC");
+				WRITE_STRING_FIELD(refname, ((PLpgSQL_rec *) d)->refname);
+				break;
+			case PLPGSQL_DTYPE_RECFIELD:
+				WRITE_STRING_FIELD(type, "RECFIELD");
+				WRITE_STRING_FIELD(fieldname, ((PLpgSQL_recfield *) d)->fieldname);
+				WRITE_INT_FIELD(recparentno, ((PLpgSQL_recfield *) d)->recparentno);
+				break;
+			case PLPGSQL_DTYPE_ARRAYELEM:
+				WRITE_STRING_FIELD(type, "ARRAYELEM");
+				WRITE_INT_FIELD(arrayparentno, ((PLpgSQL_arrayelem *) d)->arrayparentno);
+				dump_expr(str, ((PLpgSQL_arrayelem *) d)->subscript);
+				break;
+			default:
+				WRITE_STRING_FIELD(type, "UNKNOWN");
+				WRITE_INT_FIELD(dtype, d->dtype);
+		}
+		removeTrailingDelimiter(str);
+		appendStringInfoString(str, "}, ");
+	}
+
+	removeTrailingDelimiter(str);
+
+	appendStringInfoString(str, "], ");
+	appendStringInfoString(str, "\"definition\": ");
+
+  appendStringInfoChar(str, '{');
+	WRITE_INT_FIELD(lineno, func->action->lineno);
+	dump_block(str, func->action);
+	appendStringInfoChar(str, '}');
+
+  appendStringInfoChar(str, '}');
+}
+
+char *
+plpgsqlToJSON(PLpgSQL_function *func)
+{
+
+	StringInfoData str;
+
+	initStringInfo(&str);
+  dump_function(&str, func);
+
+  return str.data;
+}

--- a/ext/pg_query/pg_plpgsql_to_json.h
+++ b/ext/pg_query/pg_plpgsql_to_json.h
@@ -1,0 +1,3 @@
+#include "plpgsql.h"
+
+char* plpgsqlToJSON(PLpgSQL_function* func);

--- a/ext/pg_query/pg_polyfills.c
+++ b/ext/pg_query/pg_polyfills.c
@@ -1,6 +1,7 @@
 /* Polyfills to avoid building unnecessary objects from the PostgreSQL source */
 
 #include "postgres.h"
+#include "plpgsql.h"
 
 /* src/backend/postmaster/postmaster.c */
 bool ClientAuthInProgress = false;
@@ -20,6 +21,7 @@ int client_min_messages = NOTICE;
 int log_min_error_statement = ERROR;
 int log_min_messages = WARNING;
 int trace_recovery_messages = LOG;
+bool check_function_bodies = true;
 
 /* src/backend/storage/lmgr/proc.c */
 #include "storage/proc.h"
@@ -38,4 +40,25 @@ void check_stack_depth(void) { /* Do nothing */ }
 DefElem * defWithOids(bool value)
 {
   return makeDefElem("oids", (Node *) makeInteger(value));
+}
+
+/* src/pl/plpgsql/src/ph_handler.c */
+int plpgsql_variable_conflict = PLPGSQL_RESOLVE_ERROR;
+bool plpgsql_print_strict_params = false;
+int plpgsql_extra_warnings;
+int plpgsql_extra_errors;
+
+/* src/backend/catalog/pg_proc.c */
+#include "catalog/pg_proc_fn.h"
+bool function_parse_error_transpose(const char *prosrc)
+{
+	return false;
+}
+
+/* src/backend/parser/parse_type.c */
+#include "parser/parse_type.h"
+void parseTypeString(const char *str, Oid *typeid_p, int32 *typmod_p, bool missing_ok)
+{
+  *typeid_p = InvalidOid;
+  return;
 }

--- a/ext/pg_query/pg_query.c
+++ b/ext/pg_query/pg_query.c
@@ -11,5 +11,6 @@ void Init_pg_query(void)
 	cPgQuery = rb_const_get(rb_cObject, rb_intern("PgQuery"));
 
 	rb_define_singleton_method(cPgQuery, "_raw_parse", pg_query_raw_parse, 1);
+	rb_define_singleton_method(cPgQuery, "_raw_parse_plpgsql", pg_query_raw_parse_plpgsql, 1);
 	rb_define_singleton_method(cPgQuery, "normalize", pg_query_normalize, 1);
 }

--- a/ext/pg_query/pg_query.h
+++ b/ext/pg_query/pg_query.h
@@ -6,8 +6,14 @@
 
 #include <ruby.h>
 
+#define STDERR_BUFFER_LEN 4096
+//#define DEBUG
+
+VALUE new_parse_error(ErrorData* error);
+
 void Init_pg_query(void);
 VALUE pg_query_normalize(VALUE self, VALUE input);
 VALUE pg_query_raw_parse(VALUE self, VALUE input);
+VALUE pg_query_raw_parse_plpgsql(VALUE self, VALUE input);
 
 #endif

--- a/lib/pg_query.rb
+++ b/lib/pg_query.rb
@@ -3,6 +3,7 @@ require 'pg_query/parse_error'
 
 require 'pg_query/pg_query'
 require 'pg_query/parse'
+require 'pg_query/parse_plpgsql'
 require 'pg_query/filter_columns'
 require 'pg_query/fingerprint'
 require 'pg_query/param_refs'

--- a/lib/pg_query/parse_plpgsql.rb
+++ b/lib/pg_query/parse_plpgsql.rb
@@ -1,0 +1,19 @@
+class PgQuery
+  def self.parse_plpgsql(func_def)
+    parsetree, stderr = _raw_parse_plpgsql(func_def)
+
+    begin
+      parsetree = JSON.parse(parsetree, max_nesting: 1000)
+    rescue JSON::ParserError => e
+      raise ParseError.new("Failed to parse JSON", -1)
+    end
+
+    warnings = []
+    stderr.each_line do |line|
+      next unless line[/^WARNING/]
+      warnings << line.strip
+    end
+
+    PgQuery.new(func_def, parsetree, warnings)
+  end
+end

--- a/pg_query.gemspec
+++ b/pg_query.gemspec
@@ -18,14 +18,23 @@ Gem::Specification.new do |s|
     LICENSE
     Rakefile
     ext/pg_query/extconf.rb
+    ext/pg_query/pg_plpgsql_comp.c
+    ext/pg_query/pg_plpgsql.c
+    ext/pg_query/pg_plpgsql.h
     ext/pg_query/pg_polyfills.c
+    ext/pg_query/pg_polyfills.c
+    ext/pg_query/pg_query_normalize.c
+    ext/pg_query/pg_query_parse.c
+    ext/pg_query/pg_query_plpgsql.c
     ext/pg_query/pg_query.c
+    ext/pg_query/pg_query.h
     ext/pg_query/pg_query.sym
     lib/pg_query.rb
     lib/pg_query/filter_columns.rb
     lib/pg_query/fingerprint.rb
     lib/pg_query/param_refs.rb
     lib/pg_query/parse.rb
+    lib/pg_query/parse_plpgsql.rb
     lib/pg_query/parse_error.rb
     lib/pg_query/version.rb
   ]

--- a/spec/lib/parse_plpgsql_spec.rb
+++ b/spec/lib/parse_plpgsql_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe PgQuery, 'parsing PL/pgSQL' do
+  it 'parses a simple function' do
+    func_def = """
+DECLARE
+    r foo%rowtype;
+BEGIN
+    SELECT * FROM foo WHERE fooid > 0;
+    RETURN;
+END
+"""
+    func = PgQuery.parse_plpgsql(func_def)
+    expect(func.warnings).to eq []
+    expect(func.parsetree).to eq(
+{"signature"=>"inline_code_block",
+ "data_area"=>[{"entry"=>0, "type"=>"REC", "refname"=>"found"}, {"entry"=>1, "type"=>"REC", "refname"=>"r"}],
+ "definition"=>
+  {"lineno"=>4,
+   "type"=>"block",
+   "name"=>"*unnamed*",
+   "statements"=>
+    [{"lineno"=>5,
+      "type"=>"EXECSQL",
+      "query"=>"SELECT * FROM foo WHERE fooid > 0"},
+     {"lineno"=>6, "type"=>"RETURN", "expr"=>nil}]}})
+  end
+
+  it 'returns syntax errors' do
+    func_def = 'INVALID STUFF'
+    expect { PgQuery.parse_plpgsql(func_def) }.to raise_error do |error|
+      expect(error).to be_a PgQuery::ParseError
+      expect(error.message).to eq 'syntax error at or near "INVALID"'
+    end
+  end
+
+  it 'parses a function with a non-void return type' do
+    pending
+    func_def = """
+BEGIN
+    IF v_version IS NULL THEN
+        RETURN v_name;
+    END IF;
+    RETURN v_name || '/' || v_version;
+END;
+"""
+    func = PgQuery.parse_plpgsql(func_def)
+  end
+
+  it 'parses a complex function' do
+    func_def = """
+DECLARE
+    referrer_key RECORD;  -- declare a generic record to be used in a FOR
+    func_body text;
+    func_cmd text;
+BEGIN
+    func_body := 'BEGIN';
+
+    -- Notice how we scan through the results of a query in a FOR loop
+    -- using the FOR <record> construct.
+
+    FOR referrer_key IN SELECT * FROM cs_referrer_keys ORDER BY try_order LOOP
+        func_body := func_body ||
+          ' IF v_' || referrer_key.kind
+          || ' LIKE ' || quote_literal(referrer_key.key_string)
+          || ' THEN RETURN ' || quote_literal(referrer_key.referrer_type)
+          || '; END IF;' ;
+    END LOOP;
+
+    func_body := func_body || ' RETURN NULL; END;';
+
+    func_cmd :=
+      'CREATE OR REPLACE FUNCTION cs_find_referrer_type(v_host varchar,
+                                                        v_domain varchar,
+                                                        v_url varchar)
+        RETURNS varchar AS '
+      || quote_literal(func_body)
+      || ' LANGUAGE plpgsql;' ;
+
+    EXECUTE func_cmd;
+END;
+"""
+    func = PgQuery.parse_plpgsql(func_def)
+    expect(func.warnings).to eq []
+    expect(func.parsetree).to match(
+{"signature"=>"inline_code_block",
+ "data_area"=>
+  [{"entry"=>0, "type"=>"REC", "refname"=>"found"},
+   {"entry"=>1, "type"=>"REC", "refname"=>"referrer_key"},
+   {"entry"=>2, "type"=>"REC", "refname"=>"func_body"},
+   {"entry"=>3, "type"=>"REC", "refname"=>"func_cmd"},
+   {"entry"=>4, "type"=>"RECFIELD", "fieldname"=>"kind", "recparentno"=>1},
+   {"entry"=>5,
+    "type"=>"RECFIELD",
+    "fieldname"=>"key_string",
+    "recparentno"=>1},
+   {"entry"=>6,
+    "type"=>"RECFIELD",
+    "fieldname"=>"referrer_type",
+    "recparentno"=>1}],
+ "definition"=>
+  {"lineno"=>6,
+   "type"=>"block",
+   "name"=>"*unnamed*",
+   "statements"=>
+    [{"lineno"=>7, "type"=>"ASSIGN", "varno"=>2, "expr"=>"SELECT 'BEGIN'"},
+     {"lineno"=>12,
+      "type"=>"FORS",
+      "refname"=>"referrer_key",
+      "expr"=>"SELECT * FROM cs_referrer_keys ORDER BY try_order",
+      "statements"=>
+       [{"lineno"=>13,
+         "type"=>"ASSIGN",
+         "varno"=>2,
+         "expr"=>
+          "SELECT func_body ||\n          ' IF v_' || referrer_key.kind\n          || ' LIKE ' || quote_literal(referrer_key.key_string)\n          || ' THEN RETURN ' || quote_literal(referrer_key.referrer_type)\n          || '; END IF;'"}]},
+     {"lineno"=>20,
+      "type"=>"ASSIGN",
+      "varno"=>2,
+      "expr"=>"SELECT func_body || ' RETURN NULL; END;'"},
+     {"lineno"=>22,
+      "type"=>"ASSIGN",
+      "varno"=>3,
+      "expr"=>
+       "SELECT 'CREATE OR REPLACE FUNCTION cs_find_referrer_type(v_host varchar,\n                                                        v_domain varchar,\n                                                        v_url varchar)\n        RETURNS varchar AS '\n      || quote_literal(func_body)\n      || ' LANGUAGE plpgsql;'"},
+     {"lineno"=>30,
+      "type"=>"EXECUTE",
+      "expr"=>"SELECT func_cmd",
+      "strict"=>false},
+     {"lineno"=>0, "type"=>"RETURN", "expr"=>nil}]}})
+  end
+end


### PR DESCRIPTION
## Scope

Its useful to find SQL statements inside function definitions, in order to associate the function with the normalized query statistics inside pg_stat_statements.

This implements basic parsing support using the existing PL/pgSQL parser - using a few polyfills in the source tree here, but no parser patches.

## TODO

* [ ] Implement a dummy type mapping layer for built-in Postgres types (use `pg_type.h` definitions)
* [ ] Fix return type handling (allow specifying that part of the definition)
* [ ] Return a new Ruby object instead of `PgQuery`
* [ ] Complete conversion of output methods to JSON
* [ ] More extensive test suite
