### PR TITLE
put OR in parens

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -126,6 +126,8 @@ class PgQuery
       output.join
     end
 
+
+
     def deparse_a_indices(node)
       format('[%s]', deparse_item(node['uidx']))
     end
@@ -189,9 +191,11 @@ class PgQuery
 
     def deparse_aexpr_or(node)
       output = []
+      output << '('
       output << deparse_item(node['lexpr'])
       output << 'OR'
       output << deparse_item(node['rexpr'])
+      output << ')'
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -190,13 +190,9 @@ class PgQuery
     end
 
     def deparse_aexpr_or(node)
-      output = []
-      output << '('
-      output << deparse_item(node['lexpr'])
-      output << 'OR'
-      output << deparse_item(node['rexpr'])
-      output << ')'
-      output.join(' ')
+      lexpr = format(node['lexpr'].keys[0] == 'AEXPR AND' ? "(%s)" : "%s", deparse_item(node['lexpr']))
+      rexpr = format(node['rexpr'].keys[0] == 'AEXPR AND' ? "(%s)" : "%s", deparse_item(node['rexpr']))
+      format('(%s OR %s)', lexpr, rexpr)
     end
 
     def deparse_aexpr_any(node)

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -132,12 +132,17 @@ describe PgQuery do
       end
 
       context 'OR' do
-        let(:query) { "SELECT * FROM x WHERE ( x OR y )" }
+        let(:query) { "SELECT * FROM x WHERE (x OR y)" }
         it { is_expected.to eq query }
       end
 
       context 'OR with parens' do
-        let(:query) { "SELECT 1 WHERE ( 1 = 1 OR 1 = 2 ) AND 1 = 2" }
+        let(:query) { "SELECT 1 WHERE (1 = 1 OR 1 = 2) AND 1 = 2" }
+        it { is_expected.to eq query }
+      end
+
+      context 'OR with nested AND' do
+        let(:query) { "SELECT 1 WHERE ((1 = 1 AND 2 = 2) OR 2 = 3)" }
         it { is_expected.to eq query }
       end
 

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -132,7 +132,12 @@ describe PgQuery do
       end
 
       context 'OR' do
-        let(:query) { "SELECT * FROM x WHERE x OR y" }
+        let(:query) { "SELECT * FROM x WHERE ( x OR y )" }
+        it { is_expected.to eq query }
+      end
+
+      context 'OR with parens' do
+        let(:query) { "SELECT 1 WHERE ( 1 = 1 OR 1 = 2 ) AND 1 = 2" }
         it { is_expected.to eq query }
       end
 


### PR DESCRIPTION
Hi Lukas!

I am not sure about this change. 

These queries certainly produce different results:

SELECT 1 WHERE ( 1 = 1 OR 1 = 2 ) AND 1 = 2;
SELECT 1 WHERE 1 = 1 OR 1 = 2 AND 1 = 2;

However, there is no way in the parsetree to know where the parentheses were. Here, I am just putting OR statements in parentheses to make it work for my use case.

Maybe there is a better solution?

Cheers