### PR TITLE
deparse multiple queries

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1,423 +1,428 @@
 class PgQuery
   def deparse(tree = @parsetree)
-    output = []
-    tree.each do |item|
-      output << deparse_item(item)
-    end
-    output.join(';')
+    self.class.deparse_all(tree).join(';')
   end
 
-  private
+  class << self
 
-  def deparse_item(item, context = nil) # rubocop:disable Metrics/CyclomaticComplexity
-    return if item.nil?
-
-    type = item.keys[0]
-    node = item.values[0]
-
-    case type
-    when 'RANGEVAR'
-      deparse_rangevar(node)
-    when 'AEXPR'
-      deparse_aexpr(node)
-    when 'COLUMNREF'
-      deparse_columnref(node)
-    when 'A_CONST'
-      deparse_a_const(node)
-    when 'A_STAR'
-      deparse_a_star(node)
-    when 'A_INDIRECTION'
-      deparse_a_indirection(node)
-    when 'A_INDICES'
-      deparse_a_indices(node)
-    when 'ALIAS'
-      deparse_alias(node)
-    when 'PARAMREF'
-      deparse_paramref(node)
-    when 'RESTARGET'
-      deparse_restarget(node, context)
-    when 'FUNCCALL'
-      deparse_funccall(node)
-    when 'RANGEFUNCTION'
-      deparse_range_function(node)
-    when 'AEXPR AND'
-      deparse_aexpr_and(node)
-    when 'JOINEXPR'
-      deparse_joinexpr(node)
-    when 'SORTBY'
-      deparse_sortby(node)
-    when 'SELECT'
-      deparse_select(node)
-    when 'WITHCLAUSE'
-      deparse_with_clause(node)
-    when 'COMMONTABLEEXPR'
-      deparse_cte(node)
-    when 'INSERT INTO'
-      deparse_insert_into(node)
-    when 'UPDATE'
-      deparse_update(node)
-    when 'TYPECAST'
-      deparse_typecast(node)
-    when 'TYPENAME'
-      deparse_typename(node)
-    when 'CASE'
-      deparse_case(node)
-    when 'WHEN'
-      deparse_when(node)
-    when 'SUBLINK'
-      deparse_sublink(node)
-    when 'RANGESUBSELECT'
-      deparse_rangesubselect(node)
-    when 'AEXPR IN'
-      deparse_aexpr_in(node)
-    when 'AEXPR NOT'
-      deparse_aexpr_not(node)
-    when 'AEXPR OR'
-      deparse_aexpr_or(node)
-    when 'AEXPR ANY'
-      deparse_aexpr_any(node)
-    when 'NULLTEST'
-      deparse_nulltest(node)
-    when 'TRANSACTION'
-      deparse_transaction(node)
-    when 'COALESCE'
-      deparse_coalesce(node)
-    when 'DELETE FROM'
-      deparse_delete_from(node)
-    when 'A_TRUNCATED'
-      '...' # pg_query internal
-    else
-      fail format("Can't deparse: %s: %s", type, node.inspect)
-    end
-  end
-
-  def deparse_rangevar(node)
-    output = []
-    output << node['relname']
-    output << deparse_item(node['alias']) if node['alias']
-    output.join(' ')
-  end
-
-  def deparse_columnref(node)
-    node['fields'].map do |field|
-      field.is_a?(String) ? field : deparse_item(field)
-    end.join('.')
-  end
-
-  def deparse_a_const(node)
-    node['val'].inspect.gsub('"', '\'')
-  end
-
-  def deparse_a_star(_node)
-    '*'
-  end
-
-  def deparse_a_indirection(node)
-    output = [deparse_item(node['arg'])]
-    node['indirection'].each do |subnode|
-      output << deparse_item(subnode)
-    end
-    output.join
-  end
-
-  def deparse_a_indices(node)
-    format('[%s]', deparse_item(node['uidx']))
-  end
-
-  def deparse_alias(node)
-    node['aliasname']
-  end
-
-  def deparse_paramref(node)
-    if node['number'] == 0
-      '?'
-    else
-      format('$%d', node['number'])
-    end
-  end
-
-  def deparse_restarget(node, context)
-    if context == :select
-      [deparse_item(node['val']), node['name']].compact.join(' AS ')
-    elsif context == :update
-      [node['name'], deparse_item(node['val'])].compact.join(' = ')
-    elsif node['val'].nil?
-      node['name']
-    else
-      fail format("Can't deparse %s in context %s", node.inspect, context)
-    end
-  end
-
-  def deparse_funccall(node)
-    args = Array(node['args']).map { |arg| deparse_item(arg) }
-    format('%s(%s)', node['funcname'].join('.'), args.join(', '))
-  end
-
-  def deparse_aexpr_in(node)
-    rexpr = Array(node['rexpr']).map { |arg| deparse_item(arg) }
-    format('%s IN (%s)', deparse_item(node['lexpr']), rexpr.join(', '))
-  end
-
-  def deparse_aexpr_not(node)
-    format('NOT %s', deparse_item(node['rexpr']))
-  end
-
-  def deparse_range_function(node)
-    output = []
-    output << 'LATERAL' if node['lateral']
-    output << deparse_item(node['functions'][0][0]) # FIXME: Needs more test cases
-    output << deparse_item(node['alias']) if node['alias']
-    output.join(' ')
-  end
-
-  def deparse_aexpr(node)
-    output = []
-    output << deparse_item(node['lexpr'])
-    output << deparse_item(node['rexpr'])
-    output.join(' ' + node['name'][0] + ' ')
-  end
-
-  def deparse_aexpr_and(node)
-    format('%s AND %s', deparse_item(node['lexpr']), deparse_item(node['rexpr']))
-  end
-
-  def deparse_aexpr_or(node)
-    output = []
-    output << deparse_item(node['lexpr'])
-    output << 'OR'
-    output << deparse_item(node['rexpr'])
-    output.join(' ')
-  end
-
-  def deparse_aexpr_any(node)
-    output = []
-    output << deparse_item(node['lexpr'])
-    output << format('ANY(%s)', deparse_item(node['rexpr']))
-    output.join(' ' + node['name'][0] + ' ')
-  end
-
-  def deparse_joinexpr(node)
-    output = []
-    output << deparse_item(node['larg'])
-    output << 'LEFT' if node['jointype'] == 1
-    output << 'JOIN'
-    output << deparse_item(node['rarg'])
-
-    if node['quals']
-      output << 'ON'
-      output << deparse_item(node['quals'])
-    end
-
-    output.join(' ')
-  end
-
-  def deparse_sortby(node)
-    output = []
-    output << deparse_item(node['node'])
-    output << 'ASC' if node['sortby_dir'] == 1
-    output.join(' ')
-  end
-
-  def deparse_with_clause(node)
-    output = ['WITH']
-    output << 'RECURSIVE' if node['recursive']
-    output << node['ctes'].map do |cte|
-      deparse_item(cte)
-    end.join(', ')
-    output.join(' ')
-  end
-
-  def deparse_cte(node)
-    output = ''
-    output += node['ctename']
-    output += format('(%s)', node['aliascolnames'].join(', ')) if node['aliascolnames']
-    output += format(' AS (%s)', deparse_item(node['ctequery']))
-    output
-  end
-
-  def deparse_case(node)
-    output = ['CASE']
-    output += node['args'].map { |arg| deparse_item(arg) }
-    if node['defresult']
-      output << 'ELSE'
-      output << deparse_item(node['defresult'])
-    end
-    output << 'END'
-    output.join(' ')
-  end
-
-  def deparse_when(node)
-    output = ['WHEN']
-    output << deparse_item(node['expr'])
-    output << 'THEN'
-    output << deparse_item(node['result'])
-    output.join(' ')
-  end
-
-  def deparse_sublink(node)
-    if node['subLinkType'] == 2 && node['operName'] == ['=']
-      return format('%s IN (%s)', deparse_item(node['testexpr']), deparse_item(node['subselect']))
-    elsif node['subLinkType'] == 0
-      return format('EXISTS(%s)', deparse_item(node['subselect']))
-    else
-      return format('(%s)', deparse_item(node['subselect']))
-    end
-  end
-
-  def deparse_rangesubselect(node)
-    output = '('
-    output += deparse_item(node['subquery'])
-    output += ')'
-    output += ' ' + node['alias']['ALIAS']['aliasname'] if node['alias']
-    output
-  end
-
-  def deparse_select(node) # rubocop:disable Metrics/CyclomaticComplexity
-    output = []
-
-    if node['op'] == 1
-      output << deparse_item(node['larg'])
-      output << 'UNION'
-      output << 'ALL' if node['all']
-      output << deparse_item(node['rarg'])
-      return output.join(' ')
-    end
-
-    output << deparse_item(node['withClause']) if node['withClause']
-
-    if node['targetList']
-      output << 'SELECT'
-      output << node['targetList'].map do |item|
-        deparse_item(item, :select)
-      end.join(', ')
-    end
-
-    if node['fromClause']
-      output << 'FROM'
-      output << node['fromClause'].map do |item|
+    def deparse_all(tree)
+      tree.map do |item|
         deparse_item(item)
-      end.join(', ')
-    end
-
-    if node['whereClause']
-      output << 'WHERE'
-      output << deparse_item(node['whereClause'])
-    end
-
-    if node['valuesLists']
-      output << 'VALUES'
-      output << node['valuesLists'].map do |value_list|
-        '(' + value_list.map { |v| deparse_item(v) }.join(', ') + ')'
-      end.join(', ')
-    end
-
-    if node['groupClause']
-      output << 'GROUP BY'
-      output << node['groupClause'].map do |item|
-        deparse_item(item)
-      end.join(', ')
-    end
-
-    if node['sortClause']
-      output << 'ORDER BY'
-      output << node['sortClause'].map do |item|
-        deparse_item(item)
-      end.join(', ')
-    end
-
-    output.join(' ')
-  end
-
-  def deparse_insert_into(node)
-    output = ['INSERT INTO']
-    output << deparse_item(node['relation'])
-
-    output << '(' + node['cols'].map do |column|
-      deparse_item(column)
-    end.join(', ') + ')'
-
-    output << deparse_item(node['selectStmt'])
-
-    output.join(' ')
-  end
-
-  def deparse_update(node)
-    output = ['UPDATE']
-    output << deparse_item(node['relation'])
-
-    if node['targetList']
-      output << 'SET'
-      node['targetList'].each do |item|
-        output << deparse_item(item, :update)
       end
     end
 
-    if node['whereClause']
-      output << 'WHERE'
-      output << deparse_item(node['whereClause'])
+    private
+
+    def deparse_item(item, context = nil) # rubocop:disable Metrics/CyclomaticComplexity
+      return if item.nil?
+
+      type = item.keys[0]
+      node = item.values[0]
+
+      case type
+      when 'RANGEVAR'
+        deparse_rangevar(node)
+      when 'AEXPR'
+        deparse_aexpr(node)
+      when 'COLUMNREF'
+        deparse_columnref(node)
+      when 'A_CONST'
+        deparse_a_const(node)
+      when 'A_STAR'
+        deparse_a_star(node)
+      when 'A_INDIRECTION'
+        deparse_a_indirection(node)
+      when 'A_INDICES'
+        deparse_a_indices(node)
+      when 'ALIAS'
+        deparse_alias(node)
+      when 'PARAMREF'
+        deparse_paramref(node)
+      when 'RESTARGET'
+        deparse_restarget(node, context)
+      when 'FUNCCALL'
+        deparse_funccall(node)
+      when 'RANGEFUNCTION'
+        deparse_range_function(node)
+      when 'AEXPR AND'
+        deparse_aexpr_and(node)
+      when 'JOINEXPR'
+        deparse_joinexpr(node)
+      when 'SORTBY'
+        deparse_sortby(node)
+      when 'SELECT'
+        deparse_select(node)
+      when 'WITHCLAUSE'
+        deparse_with_clause(node)
+      when 'COMMONTABLEEXPR'
+        deparse_cte(node)
+      when 'INSERT INTO'
+        deparse_insert_into(node)
+      when 'UPDATE'
+        deparse_update(node)
+      when 'TYPECAST'
+        deparse_typecast(node)
+      when 'TYPENAME'
+        deparse_typename(node)
+      when 'CASE'
+        deparse_case(node)
+      when 'WHEN'
+        deparse_when(node)
+      when 'SUBLINK'
+        deparse_sublink(node)
+      when 'RANGESUBSELECT'
+        deparse_rangesubselect(node)
+      when 'AEXPR IN'
+        deparse_aexpr_in(node)
+      when 'AEXPR NOT'
+        deparse_aexpr_not(node)
+      when 'AEXPR OR'
+        deparse_aexpr_or(node)
+      when 'AEXPR ANY'
+        deparse_aexpr_any(node)
+      when 'NULLTEST'
+        deparse_nulltest(node)
+      when 'TRANSACTION'
+        deparse_transaction(node)
+      when 'COALESCE'
+        deparse_coalesce(node)
+      when 'DELETE FROM'
+        deparse_delete_from(node)
+      when 'A_TRUNCATED'
+        '...' # pg_query internal
+      else
+        fail format("Can't deparse: %s: %s", type, node.inspect)
+      end
     end
 
-    output.join(' ')
-  end
-
-  def deparse_typecast(node)
-    if deparse_item(node['typeName']) == :boolean
-      deparse_item(node['arg']) == "'t'" ? 'true' : 'false'
-    else
-      deparse_item(node['arg']) + '::' + deparse_typename(node['typeName']['TYPENAME'])
-    end
-  end
-
-  def deparse_typename(node)
-    if node['names'] == %w(pg_catalog bool)
-      :boolean
-    else
-      node['names'].join('.')
-    end
-  end
-
-  def deparse_nulltest(node)
-    output = [deparse_item(node['arg'])]
-    if node['nulltesttype'] == 0
-      output << 'IS NULL'
-    elsif node['nulltesttype'] == 1
-      output << 'IS NOT NULL'
-    end
-    output.join(' ')
-  end
-
-  TRANSACTION_CMDS = {
-    0 => 'BEGIN',
-    2 => 'COMMIT',
-    3 => 'ROLLBACK',
-    4 => 'SAVEPOINT',
-    5 => 'RELEASE',
-    6 => 'ROLLBACK TO SAVEPOINT'
-  }
-  def deparse_transaction(node)
-    output = []
-    output << TRANSACTION_CMDS[node['kind']] || fail(format("Can't deparse TRANSACTION %s", node.inspect))
-
-    if node['options'] && node['options'][0]['DEFELEM']
-      output << node['options'][0]['DEFELEM']['arg']
+    def deparse_rangevar(node)
+      output = []
+      output << node['relname']
+      output << deparse_item(node['alias']) if node['alias']
+      output.join(' ')
     end
 
-    output.join(' ')
-  end
-
-  def deparse_coalesce(node)
-    format('COALESCE(%s)', node['args'].map { |a| deparse_item(a) }.join(', '))
-  end
-
-  def deparse_delete_from(node)
-    output = ['DELETE FROM']
-    output << deparse_item(node['relation'])
-
-    if node['whereClause']
-      output << 'WHERE'
-      output << deparse_item(node['whereClause'])
+    def deparse_columnref(node)
+      node['fields'].map do |field|
+        field.is_a?(String) ? field : deparse_item(field)
+      end.join('.')
     end
 
-    output.join(' ')
+    def deparse_a_const(node)
+      node['val'].inspect.gsub('"', '\'')
+    end
+
+    def deparse_a_star(_node)
+      '*'
+    end
+
+    def deparse_a_indirection(node)
+      output = [deparse_item(node['arg'])]
+      node['indirection'].each do |subnode|
+        output << deparse_item(subnode)
+      end
+      output.join
+    end
+
+    def deparse_a_indices(node)
+      format('[%s]', deparse_item(node['uidx']))
+    end
+
+    def deparse_alias(node)
+      node['aliasname']
+    end
+
+    def deparse_paramref(node)
+      if node['number'] == 0
+        '?'
+      else
+        format('$%d', node['number'])
+      end
+    end
+
+    def deparse_restarget(node, context)
+      if context == :select
+        [deparse_item(node['val']), node['name']].compact.join(' AS ')
+      elsif context == :update
+        [node['name'], deparse_item(node['val'])].compact.join(' = ')
+      elsif node['val'].nil?
+        node['name']
+      else
+        fail format("Can't deparse %s in context %s", node.inspect, context)
+      end
+    end
+
+    def deparse_funccall(node)
+      args = Array(node['args']).map { |arg| deparse_item(arg) }
+      format('%s(%s)', node['funcname'].join('.'), args.join(', '))
+    end
+
+    def deparse_aexpr_in(node)
+      rexpr = Array(node['rexpr']).map { |arg| deparse_item(arg) }
+      format('%s IN (%s)', deparse_item(node['lexpr']), rexpr.join(', '))
+    end
+
+    def deparse_aexpr_not(node)
+      format('NOT %s', deparse_item(node['rexpr']))
+    end
+
+    def deparse_range_function(node)
+      output = []
+      output << 'LATERAL' if node['lateral']
+      output << deparse_item(node['functions'][0][0]) # FIXME: Needs more test cases
+      output << deparse_item(node['alias']) if node['alias']
+      output.join(' ')
+    end
+
+    def deparse_aexpr(node)
+      output = []
+      output << deparse_item(node['lexpr'])
+      output << deparse_item(node['rexpr'])
+      output.join(' ' + node['name'][0] + ' ')
+    end
+
+    def deparse_aexpr_and(node)
+      format('%s AND %s', deparse_item(node['lexpr']), deparse_item(node['rexpr']))
+    end
+
+    def deparse_aexpr_or(node)
+      output = []
+      output << deparse_item(node['lexpr'])
+      output << 'OR'
+      output << deparse_item(node['rexpr'])
+      output.join(' ')
+    end
+
+    def deparse_aexpr_any(node)
+      output = []
+      output << deparse_item(node['lexpr'])
+      output << format('ANY(%s)', deparse_item(node['rexpr']))
+      output.join(' ' + node['name'][0] + ' ')
+    end
+
+    def deparse_joinexpr(node)
+      output = []
+      output << deparse_item(node['larg'])
+      output << 'LEFT' if node['jointype'] == 1
+      output << 'JOIN'
+      output << deparse_item(node['rarg'])
+
+      if node['quals']
+        output << 'ON'
+        output << deparse_item(node['quals'])
+      end
+
+      output.join(' ')
+    end
+
+    def deparse_sortby(node)
+      output = []
+      output << deparse_item(node['node'])
+      output << 'ASC' if node['sortby_dir'] == 1
+      output.join(' ')
+    end
+
+    def deparse_with_clause(node)
+      output = ['WITH']
+      output << 'RECURSIVE' if node['recursive']
+      output << node['ctes'].map do |cte|
+        deparse_item(cte)
+      end.join(', ')
+      output.join(' ')
+    end
+
+    def deparse_cte(node)
+      output = ''
+      output += node['ctename']
+      output += format('(%s)', node['aliascolnames'].join(', ')) if node['aliascolnames']
+      output += format(' AS (%s)', deparse_item(node['ctequery']))
+      output
+    end
+
+    def deparse_case(node)
+      output = ['CASE']
+      output += node['args'].map { |arg| deparse_item(arg) }
+      if node['defresult']
+        output << 'ELSE'
+        output << deparse_item(node['defresult'])
+      end
+      output << 'END'
+      output.join(' ')
+    end
+
+    def deparse_when(node)
+      output = ['WHEN']
+      output << deparse_item(node['expr'])
+      output << 'THEN'
+      output << deparse_item(node['result'])
+      output.join(' ')
+    end
+
+    def deparse_sublink(node)
+      if node['subLinkType'] == 2 && node['operName'] == ['=']
+        return format('%s IN (%s)', deparse_item(node['testexpr']), deparse_item(node['subselect']))
+      elsif node['subLinkType'] == 0
+        return format('EXISTS(%s)', deparse_item(node['subselect']))
+      else
+        return format('(%s)', deparse_item(node['subselect']))
+      end
+    end
+
+    def deparse_rangesubselect(node)
+      output = '('
+      output += deparse_item(node['subquery'])
+      output += ')'
+      output += ' ' + node['alias']['ALIAS']['aliasname'] if node['alias']
+      output
+    end
+
+    def deparse_select(node) # rubocop:disable Metrics/CyclomaticComplexity
+      output = []
+
+      if node['op'] == 1
+        output << deparse_item(node['larg'])
+        output << 'UNION'
+        output << 'ALL' if node['all']
+        output << deparse_item(node['rarg'])
+        return output.join(' ')
+      end
+
+      output << deparse_item(node['withClause']) if node['withClause']
+
+      if node['targetList']
+        output << 'SELECT'
+        output << node['targetList'].map do |item|
+          deparse_item(item, :select)
+        end.join(', ')
+      end
+
+      if node['fromClause']
+        output << 'FROM'
+        output << node['fromClause'].map do |item|
+          deparse_item(item)
+        end.join(', ')
+      end
+
+      if node['whereClause']
+        output << 'WHERE'
+        output << deparse_item(node['whereClause'])
+      end
+
+      if node['valuesLists']
+        output << 'VALUES'
+        output << node['valuesLists'].map do |value_list|
+          '(' + value_list.map { |v| deparse_item(v) }.join(', ') + ')'
+        end.join(', ')
+      end
+
+      if node['groupClause']
+        output << 'GROUP BY'
+        output << node['groupClause'].map do |item|
+          deparse_item(item)
+        end.join(', ')
+      end
+
+      if node['sortClause']
+        output << 'ORDER BY'
+        output << node['sortClause'].map do |item|
+          deparse_item(item)
+        end.join(', ')
+      end
+
+      output.join(' ')
+    end
+
+    def deparse_insert_into(node)
+      output = ['INSERT INTO']
+      output << deparse_item(node['relation'])
+
+      output << '(' + node['cols'].map do |column|
+        deparse_item(column)
+      end.join(', ') + ')'
+
+      output << deparse_item(node['selectStmt'])
+
+      output.join(' ')
+    end
+
+    def deparse_update(node)
+      output = ['UPDATE']
+      output << deparse_item(node['relation'])
+
+      if node['targetList']
+        output << 'SET'
+        node['targetList'].each do |item|
+          output << deparse_item(item, :update)
+        end
+      end
+
+      if node['whereClause']
+        output << 'WHERE'
+        output << deparse_item(node['whereClause'])
+      end
+
+      output.join(' ')
+    end
+
+    def deparse_typecast(node)
+      if deparse_item(node['typeName']) == :boolean
+        deparse_item(node['arg']) == "'t'" ? 'true' : 'false'
+      else
+        deparse_item(node['arg']) + '::' + deparse_typename(node['typeName']['TYPENAME'])
+      end
+    end
+
+    def deparse_typename(node)
+      if node['names'] == %w(pg_catalog bool)
+        :boolean
+      else
+        node['names'].join('.')
+      end
+    end
+
+    def deparse_nulltest(node)
+      output = [deparse_item(node['arg'])]
+      if node['nulltesttype'] == 0
+        output << 'IS NULL'
+      elsif node['nulltesttype'] == 1
+        output << 'IS NOT NULL'
+      end
+      output.join(' ')
+    end
+
+    TRANSACTION_CMDS = {
+      0 => 'BEGIN',
+      2 => 'COMMIT',
+      3 => 'ROLLBACK',
+      4 => 'SAVEPOINT',
+      5 => 'RELEASE',
+      6 => 'ROLLBACK TO SAVEPOINT'
+    }
+    def deparse_transaction(node)
+      output = []
+      output << TRANSACTION_CMDS[node['kind']] || fail(format("Can't deparse TRANSACTION %s", node.inspect))
+
+      if node['options'] && node['options'][0]['DEFELEM']
+        output << node['options'][0]['DEFELEM']['arg']
+      end
+
+      output.join(' ')
+    end
+
+    def deparse_coalesce(node)
+      format('COALESCE(%s)', node['args'].map { |a| deparse_item(a) }.join(', '))
+    end
+
+    def deparse_delete_from(node)
+      output = ['DELETE FROM']
+      output << deparse_item(node['relation'])
+
+      if node['whereClause']
+        output << 'WHERE'
+        output << deparse_item(node['whereClause'])
+      end
+
+      output.join(' ')
+    end
   end
 end

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1,14 +1,17 @@
 class PgQuery
+  # Reconstruct all of the parsed queries into their original form
   def deparse(tree = @parsetree)
-    self.class.deparse_all(tree).join(';')
+    tree.map do |item|
+      self.class.deparse(item)
+    end.join('; ')
   end
 
   class << self
 
-    def deparse_all(tree)
-      tree.map do |item|
-        deparse_item(item)
-      end
+    # Given one element of the PgQuery#parsetree reconstruct it back into the
+    # original query.
+    def deparse(item)
+      deparse_item(item)
     end
 
     private

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -1,50 +1,233 @@
 require 'spec_helper'
 
-describe PgQuery, '#deparse' do
-  subject { described_class.parse(oneline_query).deparse }
+describe PgQuery do
+  let(:oneline_query) { query.gsub(/\s+/, ' ').gsub('( ', '(').gsub(' )', ')').strip.chomp(';') }
+  let(:parsetree) { described_class.parse(oneline_query).parsetree }
 
-  let(:oneline_query) { query.gsub(/\s+/, ' ').gsub('( ', '(').gsub(' )', ')').strip }
+  describe '.deparse' do
+    subject { described_class.deparse(parsetree.first) }
 
-  context 'SELECT' do
-    context 'basic statement' do
-      let(:query) { 'SELECT a AS b FROM x WHERE y = 5 AND z = y' }
-      it { is_expected.to eq query }
-    end
-
-    context 'complex SELECT statement' do
-      let(:query) { "SELECT memory_total_bytes, memory_swap_total_bytes - memory_swap_free_bytes AS swap, date_part(?, s.collected_at) AS collected_at FROM snapshots s JOIN system_snapshots ON snapshot_id = s.id WHERE s.database_id = ? AND s.collected_at >= ? AND s.collected_at <= ? ORDER BY collected_at ASC" }
-      it { is_expected.to eq query }
-    end
-
-    context 'simple WITH statement' do
-      let(:query) { 'WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM t' }
-      it { is_expected.to eq query }
-    end
-
-    context 'complex WITH statement' do
-      let(:query) do
-        """
-        WITH RECURSIVE employee_recursive(distance, employee_name, manager_name) AS (
-          SELECT 1, employee_name, manager_name
-          FROM employee
-          WHERE manager_name = 'Mary'
-        UNION ALL
-          SELECT er.distance + 1, e.employee_name, e.manager_name
-          FROM employee_recursive er, employee e
-          WHERE er.employee_name = e.manager_name
-        )
-        SELECT distance, employee_name FROM employee_recursive
-        """
+    context 'SELECT' do
+      context 'basic statement' do
+        let(:query) { 'SELECT a AS b FROM x WHERE y = 5 AND z = y' }
+        it { is_expected.to eq query }
       end
-      it { is_expected.to eq oneline_query }
+
+      context 'complex SELECT statement' do
+        let(:query) { "SELECT memory_total_bytes, memory_swap_total_bytes - memory_swap_free_bytes AS swap, date_part(?, s.collected_at) AS collected_at FROM snapshots s JOIN system_snapshots ON snapshot_id = s.id WHERE s.database_id = ? AND s.collected_at >= ? AND s.collected_at <= ? ORDER BY collected_at ASC" }
+        it { is_expected.to eq query }
+      end
+
+      context 'simple WITH statement' do
+        let(:query) { 'WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM t' }
+        it { is_expected.to eq query }
+      end
+
+      context 'complex WITH statement' do
+        let(:query) do
+          """
+          WITH RECURSIVE employee_recursive(distance, employee_name, manager_name) AS (
+            SELECT 1, employee_name, manager_name
+            FROM employee
+            WHERE manager_name = 'Mary'
+          UNION ALL
+            SELECT er.distance + 1, e.employee_name, e.manager_name
+            FROM employee_recursive er, employee e
+            WHERE er.employee_name = e.manager_name
+          )
+          SELECT distance, employee_name FROM employee_recursive
+          """
+        end
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'LATERAL' do
+        let(:query) { 'SELECT m.name AS mname, pname FROM manufacturers m, LATERAL get_product_names(m.id) pname' }
+        it { is_expected.to eq query }
+      end
+
+      context 'LATERAL JOIN' do
+        let(:query) do
+          """
+          SELECT m.name AS mname, pname
+            FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true
+          """
+        end
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'omitted FROM clause' do
+        let(:query) { 'SELECT 2 + 2' }
+        it { is_expected.to eq query }
+      end
+
+      context 'IS NULL' do
+        let(:query) { 'SELECT * FROM x WHERE y IS NULL' }
+        it { is_expected.to eq query }
+      end
+
+      context 'IS NOT NULL' do
+        let(:query) { 'SELECT * FROM x WHERE y IS NOT NULL' }
+        it { is_expected.to eq query }
+      end
+
+      context 'basic CASE WHEN statements' do
+        let(:query) { "SELECT CASE WHEN a.status = 1 THEN 'active' WHEN a.status = 2 THEN 'inactive' END FROM accounts a" }
+        it { is_expected.to eq query }
+      end
+
+      context 'CASE WHEN statements with ELSE clause' do
+        let(:query) { "SELECT CASE WHEN a.status = 1 THEN 'active' WHEN a.status = 2 THEN 'inactive' ELSE 'unknown' END FROM accounts a" }
+        it { is_expected.to eq query }
+      end
+
+      context 'CASE WHEN statements in WHERE clause' do
+        let(:query) { "SELECT * FROM accounts WHERE status = CASE WHEN x = 1 THEN 'active' ELSE 'inactive' END" }
+        it { is_expected.to eq query }
+      end
+
+      context 'CASE WHEN EXISTS' do
+        let(:query) { "SELECT CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 2 END" }
+        it { is_expected.to eq query }
+      end
+
+      context 'Subselect in SELECT clause' do
+        let(:query) { "SELECT (SELECT 'x')" }
+        it { is_expected.to eq query }
+      end
+
+      context 'Subselect in FROM clause' do
+        let(:query) { "SELECT * FROM (SELECT generate_series(0, 100)) a" }
+        it { is_expected.to eq query }
+      end
+
+      context 'IN expression' do
+        let(:query) { "SELECT * FROM x WHERE id IN (1, 2, 3)" }
+        it { is_expected.to eq query }
+      end
+
+      context 'IN expression Subselect' do
+        let(:query) { "SELECT * FROM x WHERE id IN (SELECT id FROM account)" }
+        it { is_expected.to eq query }
+      end
+
+      context 'Subselect JOIN' do
+        let(:query) { "SELECT * FROM x JOIN (SELECT n FROM z) b ON a.id = b.id" }
+        it { is_expected.to eq query }
+      end
+
+      context 'simple indirection' do
+        let(:query) { "SELECT * FROM x WHERE y = z[?]" }
+        it { is_expected.to eq query }
+      end
+
+      context 'complex indirection' do
+        let(:query) { "SELECT * FROM x WHERE y = z[?][?]" }
+        it { is_expected.to eq query }
+      end
+
+      context 'NOT' do
+        let(:query) { "SELECT * FROM x WHERE NOT y" }
+        it { is_expected.to eq query }
+      end
+
+      context 'OR' do
+        let(:query) { "SELECT * FROM x WHERE x OR y" }
+        it { is_expected.to eq query }
+      end
+
+      context 'ANY' do
+        let(:query) { "SELECT * FROM x WHERE x = ANY(?)" }
+        it { is_expected.to eq query }
+      end
+
+      context 'COALESCE' do
+        let(:query) { "SELECT * FROM x WHERE x = COALESCE(y, ?)" }
+        it { is_expected.to eq query }
+      end
+
+      context 'GROUP BY' do
+        let(:query) { "SELECT a, b, max(c) FROM c WHERE d = 1 GROUP BY a, b" }
+        it { is_expected.to eq query }
+      end
     end
 
-    context 'LATERAL' do
-      let(:query) { 'SELECT m.name AS mname, pname FROM manufacturers m, LATERAL get_product_names(m.id) pname' }
+    context 'type cast' do
+      context 'simple case' do
+        let(:query) { "SELECT 1::int8" }
+        it { is_expected.to eq query }
+      end
+
+      context 'regclass' do
+        let(:query) { "SELECT ?::regclass" }
+        it { is_expected.to eq query }
+      end
+    end
+
+    context 'param ref' do
+      context 'normal param refs' do
+        let(:query) { "SELECT $5" }
+        it { is_expected.to eq query }
+      end
+
+      context 'query replacement character' do
+        let(:query) { "SELECT ?" }
+        it { is_expected.to eq query }
+      end
+    end
+
+    context 'basic INSERT statements' do
+      let(:query) { "INSERT INTO x (y, z) VALUES (1, 'abc')" }
       it { is_expected.to eq query }
     end
 
-    context 'LATERAL JOIN' do
+    context 'basic UPDATE statements' do
+      let(:query) { "UPDATE x SET y = 1 WHERE z = 'abc'" }
+      it { is_expected.to eq query }
+    end
+
+    context 'basic DELETE statements' do
+      let(:query) { "DELETE FROM x WHERE y = 1" }
+      it { is_expected.to eq query }
+    end
+
+    context 'TRANSACTION' do
+      context 'BEGIN' do
+        let(:query) { 'BEGIN' }
+        it { is_expected.to eq query }
+      end
+
+      context 'ROLLBACK' do
+        let(:query) { 'ROLLBACK' }
+        it { is_expected.to eq query }
+      end
+
+      context 'COMMIT' do
+        let(:query) { 'COMMIT' }
+        it { is_expected.to eq query }
+      end
+
+      context 'SAVEPOINT' do
+        let(:query) { 'SAVEPOINT x' }
+        it { is_expected.to eq query }
+      end
+
+      context 'ROLLBACK TO SAFEPOINT' do
+        let(:query) { 'ROLLBACK TO SAVEPOINT x' }
+        it { is_expected.to eq query }
+      end
+
+      context 'RELEASE' do
+        let(:query) { 'RELEASE x' }
+        it { is_expected.to eq query }
+      end
+    end
+  end
+
+  describe '#deparse' do
+    subject { described_class.parse(oneline_query).deparse }
+
+    context 'for single query' do
       let(:query) do
         """
         SELECT m.name AS mname, pname
@@ -54,170 +237,29 @@ describe PgQuery, '#deparse' do
       it { is_expected.to eq oneline_query }
     end
 
-    context 'omitted FROM clause' do
-      let(:query) { 'SELECT 2 + 2' }
-      it { is_expected.to eq query }
+    context 'for multiple queries' do
+      let(:query) do
+        """
+        SELECT m.name AS mname, pname
+          FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true;
+        INSERT INTO manufacturers_daily (a, b)
+          SELECT a, b FROM manufacturers;
+        """
+      end
+      it { is_expected.to eq oneline_query }
     end
 
-    context 'IS NULL' do
-      let(:query) { 'SELECT * FROM x WHERE y IS NULL' }
-      it { is_expected.to eq query }
-    end
-
-    context 'IS NOT NULL' do
-      let(:query) { 'SELECT * FROM x WHERE y IS NOT NULL' }
-      it { is_expected.to eq query }
-    end
-
-    context 'basic CASE WHEN statements' do
-      let(:query) { "SELECT CASE WHEN a.status = 1 THEN 'active' WHEN a.status = 2 THEN 'inactive' END FROM accounts a" }
-      it { is_expected.to eq query }
-    end
-
-    context 'CASE WHEN statements with ELSE clause' do
-      let(:query) { "SELECT CASE WHEN a.status = 1 THEN 'active' WHEN a.status = 2 THEN 'inactive' ELSE 'unknown' END FROM accounts a" }
-      it { is_expected.to eq query }
-    end
-
-    context 'CASE WHEN statements in WHERE clause' do
-      let(:query) { "SELECT * FROM accounts WHERE status = CASE WHEN x = 1 THEN 'active' ELSE 'inactive' END" }
-      it { is_expected.to eq query }
-    end
-
-    context 'CASE WHEN EXISTS' do
-      let(:query) { "SELECT CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 2 END" }
-      it { is_expected.to eq query }
-    end
-
-    context 'Subselect in SELECT clause' do
-      let(:query) { "SELECT (SELECT 'x')" }
-      it { is_expected.to eq query }
-    end
-
-    context 'Subselect in FROM clause' do
-      let(:query) { "SELECT * FROM (SELECT generate_series(0, 100)) a" }
-      it { is_expected.to eq query }
-    end
-
-    context 'IN expression' do
-      let(:query) { "SELECT * FROM x WHERE id IN (1, 2, 3)" }
-      it { is_expected.to eq query }
-    end
-
-    context 'IN expression Subselect' do
-      let(:query) { "SELECT * FROM x WHERE id IN (SELECT id FROM account)" }
-      it { is_expected.to eq query }
-    end
-
-    context 'Subselect JOIN' do
-      let(:query) { "SELECT * FROM x JOIN (SELECT n FROM z) b ON a.id = b.id" }
-      it { is_expected.to eq query }
-    end
-
-    context 'simple indirection' do
-      let(:query) { "SELECT * FROM x WHERE y = z[?]" }
-      it { is_expected.to eq query }
-    end
-
-    context 'complex indirection' do
-      let(:query) { "SELECT * FROM x WHERE y = z[?][?]" }
-      it { is_expected.to eq query }
-    end
-
-    context 'NOT' do
-      let(:query) { "SELECT * FROM x WHERE NOT y" }
-      it { is_expected.to eq query }
-    end
-
-    context 'OR' do
-      let(:query) { "SELECT * FROM x WHERE x OR y" }
-      it { is_expected.to eq query }
-    end
-
-    context 'ANY' do
-      let(:query) { "SELECT * FROM x WHERE x = ANY(?)" }
-      it { is_expected.to eq query }
-    end
-
-    context 'COALESCE' do
-      let(:query) { "SELECT * FROM x WHERE x = COALESCE(y, ?)" }
-      it { is_expected.to eq query }
-    end
-
-    context 'GROUP BY' do
-      let(:query) { "SELECT a, b, max(c) FROM c WHERE d = 1 GROUP BY a, b" }
-      it { is_expected.to eq query }
-    end
-  end
-
-  context 'type cast' do
-    context 'simple case' do
-      let(:query) { "SELECT 1::int8" }
-      it { is_expected.to eq query }
-    end
-
-    context 'regclass' do
-      let(:query) { "SELECT ?::regclass" }
-      it { is_expected.to eq query }
-    end
-  end
-
-  context 'param ref' do
-    context 'normal param refs' do
-      let(:query) { "SELECT $5" }
-      it { is_expected.to eq query }
-    end
-
-    context 'query replacement character' do
-      let(:query) { "SELECT ?" }
-      it { is_expected.to eq query }
-    end
-  end
-
-  context 'basic INSERT statements' do
-    let(:query) { "INSERT INTO x (y, z) VALUES (1, 'abc')" }
-    it { is_expected.to eq query }
-  end
-
-  context 'basic UPDATE statements' do
-    let(:query) { "UPDATE x SET y = 1 WHERE z = 'abc'" }
-    it { is_expected.to eq query }
-  end
-
-  context 'basic DELETE statements' do
-    let(:query) { "DELETE FROM x WHERE y = 1" }
-    it { is_expected.to eq query }
-  end
-
-  context 'TRANSACTION' do
-    context 'BEGIN' do
-      let(:query) { 'BEGIN' }
-      it { is_expected.to eq query }
-    end
-
-    context 'ROLLBACK' do
-      let(:query) { 'ROLLBACK' }
-      it { is_expected.to eq query }
-    end
-
-    context 'COMMIT' do
-      let(:query) { 'COMMIT' }
-      it { is_expected.to eq query }
-    end
-
-    context 'SAVEPOINT' do
-      let(:query) { 'SAVEPOINT x' }
-      it { is_expected.to eq query }
-    end
-
-    context 'ROLLBACK TO SAFEPOINT' do
-      let(:query) { 'ROLLBACK TO SAVEPOINT x' }
-      it { is_expected.to eq query }
-    end
-
-    context 'RELEASE' do
-      let(:query) { 'RELEASE x' }
-      it { is_expected.to eq query }
+    context 'for multiple queries with a semicolon inside a value' do
+      let(:query) do
+        """
+        SELECT m.name AS mname, pname
+          FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true;
+        UPDATE users SET name = 'bobby; drop tables';
+        INSERT INTO manufacturers_daily (a, b)
+          SELECT a, b FROM manufacturers;
+        """
+      end
+      it { is_expected.to eq oneline_query }
     end
   end
 end


### PR DESCRIPTION
Allow parsing either single or multiple queries

This allows a user to reconstruct each original query from a source that
may have been difficult to separate into individual SQL queries.
