### PR TITLE
Deparsing complex INSERT, UPDATE, and DELETE queries

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -430,9 +430,24 @@ class PgQuery
       output = ['DELETE FROM']
       output << deparse_item(node['relation'])
 
+      if node['usingClause']
+        output << 'USING'
+        output << node['usingClause'].map do |item|
+          deparse_item(item)
+        end.join(', ')
+      end
+
       if node['whereClause']
         output << 'WHERE'
         output << deparse_item(node['whereClause'])
+      end
+
+      if node['returningList']
+        output << 'RETURNING'
+        output << node['returningList'].map do |item|
+          # RETURNING is formatted like a SELECT
+          deparse_item(item, :select)
+        end.join(', ')
       end
 
       output.join(' ')

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -176,14 +176,30 @@ describe PgQuery do
       end
     end
 
-    context 'basic INSERT statements' do
-      let(:query) { "INSERT INTO x (y, z) VALUES (1, 'abc')" }
-      it { is_expected.to eq query }
+    context 'INSERT' do
+      context 'basic' do
+        let(:query) { "INSERT INTO x (y, z) VALUES (1, 'abc')" }
+        it { is_expected.to eq query }
+      end
+
+      context 'INTO SELECT' do
+        let(:query) { "INSERT INTO x SELECT * FROM y" }
+        it { is_expected.to eq query }
+      end
     end
 
-    context 'basic UPDATE statements' do
-      let(:query) { "UPDATE x SET y = 1 WHERE z = 'abc'" }
-      it { is_expected.to eq query }
+    context 'UPDATE' do
+      context 'basic' do
+        let(:query) { "UPDATE x SET y = 1 WHERE z = 'abc'" }
+        it { is_expected.to eq query }
+      end
+
+      context 'elaborate' do
+        let(:query) do
+         "UPDATE ONLY x table_x SET y = 1 WHERE z = 'abc' RETURNING y AS changed_y"
+        end
+        it { is_expected.to eq query }
+      end
     end
 
     context 'basic DELETE statements' do

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -202,9 +202,16 @@ describe PgQuery do
       end
     end
 
-    context 'basic DELETE statements' do
-      let(:query) { "DELETE FROM x WHERE y = 1" }
-      it { is_expected.to eq query }
+    context 'DELETE' do
+      context 'basic' do
+        let(:query) { "DELETE FROM x WHERE y = 1" }
+        it { is_expected.to eq query }
+      end
+
+      context 'elaborate' do
+        let(:query) { "DELETE FROM ONLY x table_x USING table_z WHERE y = 1 RETURNING *" }
+        it { is_expected.to eq query }
+      end
     end
 
     context 'TRANSACTION' do


### PR DESCRIPTION
There was plenty of coverage already for complex deparsing of `SELECT` queries and this adds support for `UPDATE`, `INSERT`, and `DELETE` as well.