### PR TITLE
Add all necessary files to gem

### DIFF
--- a/pg_query.gemspec
+++ b/pg_query.gemspec
@@ -14,24 +14,7 @@ Gem::Specification.new do |s|
 
   s.extensions = %w(ext/pg_query/extconf.rb)
 
-  s.files = %w(
-    LICENSE
-    Rakefile
-    ext/pg_query/extconf.rb
-    ext/pg_query/pg_polyfills.c
-    ext/pg_query/pg_query_normalize.c
-    ext/pg_query/pg_query_parse.c
-    ext/pg_query/pg_query.c
-    ext/pg_query/pg_query.h
-    ext/pg_query/pg_query.sym
-    lib/pg_query.rb
-    lib/pg_query/filter_columns.rb
-    lib/pg_query/fingerprint.rb
-    lib/pg_query/param_refs.rb
-    lib/pg_query/parse_error.rb
-    lib/pg_query/parse.rb
-    lib/pg_query/version.rb
-  )
+  s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   s.add_development_dependency 'rake-compiler', '~> 0'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Without this some core source files (like treewalker.rb) are missing from the gem. Release 0.6.0 is great prior to packaging but some of the source didn't make it to Rubygems.