### PR TITLE
Adding more detail for parser errors

### DIFF
--- a/ext/pg_query/pg_query_parse.c
+++ b/ext/pg_query/pg_query_parse.c
@@ -10,15 +10,21 @@
 VALUE new_parse_error(ErrorData* error)
 {
 	VALUE cPgQuery, cParseError;
-	VALUE args[2];
+	VALUE args[4];
 
 	cPgQuery = rb_const_get(rb_cObject, rb_intern("PgQuery"));
 	cParseError = rb_const_get_at(cPgQuery, rb_intern("ParseError"));
 
+	// exception message
 	args[0] = rb_str_new2(error->message);
-	args[1] = INT2NUM(error->cursorpos);
+	// source of exception (e.g. parse.l)
+	args[1] = rb_str_new2(error->filename);
+	// source of exception (e.g. 104)
+	args[2] = INT2NUM(error->lineno);
+	// char in query at which exception occurred
+	args[3] = INT2NUM(error->cursorpos);
 
-	return rb_class_new_instance(2, args, cParseError);
+	return rb_class_new_instance(4, args, cParseError);
 }
 
 VALUE pg_query_raw_parse(VALUE self, VALUE input)

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -7,7 +7,7 @@ class PgQuery
     begin
       parsetree = JSON.parse(parsetree, max_nesting: 1000)
     rescue JSON::ParserError
-      raise ParseError.new('Failed to parse JSON', -1)
+      raise ParseError.new('Failed to parse JSON', __FILE__, __LINE__, -1)
     end
 
     warnings = []

--- a/lib/pg_query/parse_error.rb
+++ b/lib/pg_query/parse_error.rb
@@ -1,8 +1,8 @@
 class PgQuery
   class ParseError < ArgumentError
     attr_reader :location
-    def initialize(message, location)
-      super(message)
+    def initialize(message, source_file, source_line, location)
+      super("#{message} (#{source_file}:#{source_line})")
       @location = location
     end
   end

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe PgQuery do
   let(:oneline_query) { query.gsub(/\s+/, ' ').gsub('( ', '(').gsub(' )', ')').strip.chomp(';') }
-  let(:parsetree) { described_class.parse(oneline_query).parsetree }
+  let(:parsetree) { described_class.parse(query).parsetree }
 
   describe '.deparse' do
     subject { described_class.deparse(parsetree.first) }
@@ -369,6 +369,17 @@ describe PgQuery do
         let(:query) { 'RELEASE x' }
         it { is_expected.to eq query }
       end
+    end
+
+    context 'COMMENTS' do
+      let(:query) do
+        """
+        CREATE TABLE remove_comments (
+          id int -- inline comment in multiline
+        );
+        """
+      end
+      it { is_expected.to eq("CREATE TABLE remove_comments (id int)") }
     end
   end
 

--- a/spec/lib/normalized_parsing_spec.rb
+++ b/spec/lib/normalized_parsing_spec.rb
@@ -69,7 +69,7 @@ describe PgQuery do
     # support that due to keyword/function duality (e.g. JOIN)
     expect { described_class.parse("SELECT ? 10") }.to raise_error do |error|
       expect(error).to be_a(described_class::ParseError)
-      expect(error.message).to eq "syntax error at or near \"10\""
+      expect(error.message).to eq "syntax error at or near \"10\" (scan.l:1087)"
     end
   end
 

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -9,7 +9,7 @@ describe PgQuery, '.parse' do
   it "handles errors" do
     expect { described_class.parse("SELECT 'ERR") }.to raise_error {|error|
       expect(error).to be_a(described_class::ParseError)
-      expect(error.message).to eq "unterminated quoted string at or near \"'ERR\""
+      expect(error.message).to eq "unterminated quoted string at or near \"'ERR\" (scan.l:1087)"
       expect(error.location).to eq 8 # 8th character in query string
     }
   end


### PR DESCRIPTION
This PR is mostly just an improvement for folks like us who end up doing further development of the parser. I needed a way to track the specific error back to the source in scan.l or wherever. 