### PR TITLE
Deparse CREATE VIEW and CREATE FUNCTION

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -154,7 +154,12 @@ class PgQuery
     end
 
     def deparse_alias(node)
-      node['aliasname']
+      name = node['aliasname']
+      if node['colnames']
+        name + '(' + node['colnames'].join(', ') + ')'
+      else
+        name
+      end
     end
 
     def deparse_paramref(node)
@@ -357,11 +362,12 @@ class PgQuery
     end
 
     def deparse_rangesubselect(node)
-      output = '('
-      output += deparse_item(node['subquery'])
-      output += ')'
-      output += ' ' + node['alias']['ALIAS']['aliasname'] if node['alias']
-      output
+      output = '(' + deparse_item(node['subquery']) + ')'
+      if node['alias']
+        output + ' ' + deparse_item(node['alias'])
+      else
+        output
+      end
     end
 
     def deparse_row(node)

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -18,6 +18,11 @@ describe PgQuery do
         it { is_expected.to eq query }
       end
 
+      context 'with specific column alias' do
+        let(:query) { "SELECT * FROM (VALUES ('anne', 'smith'), ('bob', 'jones'), ('joe', 'blow')) names(first, last)" }
+        it { is_expected.to eq oneline_query }
+      end
+
       context 'simple WITH statement' do
         let(:query) { 'WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM t' }
         it { is_expected.to eq query }

--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -286,6 +286,20 @@ describe PgQuery do
       end
     end
 
+    context 'CREATE FUNCTION' do
+      # Taken from http://www.postgresql.org/docs/8.3/static/queries-table-expressions.html
+      context 'with inline function definition' do
+        let(:query) do
+          """
+          CREATE FUNCTION getfoo(int) RETURNS SETOF users AS $$
+              SELECT * FROM users WHERE users.id = $1;
+          $$ language sql;
+          """
+        end
+        it { is_expected.to eq oneline_query }
+      end
+    end
+
     context 'CREATE TABLE' do
       context 'top-level' do
         let(:query) do


### PR DESCRIPTION
Loads of edge-cases handled in the deparser now as of this PR.

I've been thinking of your question about how to make the deparser portable and I can only think of writing a reverse grammar that can compile down to target languages. The spec is simple enough - it's just a bunch of strings that are provably unchanged when round-tripped through the parser/deparser. I don't have time to build it right now but it'll probably keep me awake for a few nights thinking about it.