### PR TITLE
Properly comparing multiline queries

### DIFF
--- a/spec/lib/deparse_spec.rb
+++ b/spec/lib/deparse_spec.rb
@@ -298,10 +298,10 @@ describe PgQuery do
           """
           CREATE FUNCTION getfoo(int) RETURNS SETOF users AS $$
               SELECT * FROM users WHERE users.id = $1;
-          $$ language sql;
-          """
+          $$ language sql
+          """.strip
         end
-        it { is_expected.to eq oneline_query }
+        it { is_expected.to eq query }
       end
     end
 


### PR DESCRIPTION
This fixes the build. Two of my PRs yesterday didn't play well together. Bonus: We're now able to preserve multiline queries through the parser/deparser.

