### PR TITLE
Added supported for the agg_distinct flag

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -251,7 +251,7 @@ class PgQuery
       args << '*' if node['agg_star']
 
       name = (node['funcname'] - ['pg_catalog']).join('.')
-      distinct = node['agg_distinct'] ? 'distinct ' : ''
+      distinct = node['agg_distinct'] ? 'DISTINCT ' : ''
       output << format('%s(%s%s)', name, distinct, args.join(', '))
       output << format('OVER (%s)', deparse_item(node['over'])) if node['over']
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -251,7 +251,8 @@ class PgQuery
       args << '*' if node['agg_star']
 
       name = (node['funcname'] - ['pg_catalog']).join('.')
-      output << format('%s(%s)', name, args.join(', '))
+      distinct = node['agg_distinct'] ? 'distinct ' : ''
+      output << format('%s(%s%s)', name, distinct, args.join(', '))
       output << format('OVER (%s)', deparse_item(node['over'])) if node['over']
 
       output.join(' ')

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -98,7 +98,7 @@ describe PgQuery::Deparse do
       end
 
       context 'COUNT DISTINCT' do
-        let(:query) { 'SELECT count(distinct a) FROM x WHERE y IS NOT NULL' }
+        let(:query) { 'SELECT count(DISTINCT "a") FROM x WHERE "y" IS NOT NULL' }
         it { is_expected.to eq query }
       end
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -97,6 +97,11 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'COUNT DISTINCT' do
+        let(:query) { 'SELECT count(distinct a) FROM x WHERE y IS NOT NULL' }
+        it { is_expected.to eq query }
+      end
+
       context 'basic CASE WHEN statements' do
         let(:query) { "SELECT CASE WHEN a.status = 1 THEN 'active' WHEN a.status = 2 THEN 'inactive' END FROM accounts a" }
         it { is_expected.to eq query }


### PR DESCRIPTION
Deparse disregards the `agg_distinct` flag, this test currently fails:

```ruby
context 'COUNT DISTINCT' do
    let(:query) { 'SELECT count(distinct a) FROM x WHERE y IS NOT NULL' }
    it { is_expected.to eq query }
end
```

with this message:

```
expected: "SELECT count(distinct a) FROM x WHERE y IS NOT NULL"
     got: "SELECT count(a) FROM x WHERE y IS NOT NULL"
```

Fixed here.