### PR TITLE
Quote rangevars to support special from clauses

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -136,7 +136,7 @@ class PgQuery
     def deparse_rangevar(node)
       output = []
       output << 'ONLY' if node['inhOpt'] == 0
-      output << node['relname']
+      output << '"' + node['relname'] + '"'
       output << deparse_item(node['alias']) if node['alias']
       output.join(' ')
     end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -9,12 +9,12 @@ describe PgQuery::Deparse do
 
     context 'SELECT' do
       context 'basic statement' do
-        let(:query) { 'SELECT "a" AS b FROM x WHERE "y" = 5 AND "z" = "y"' }
+        let(:query) { 'SELECT "a" AS b FROM "x" WHERE "y" = 5 AND "z" = "y"' }
         it { is_expected.to eq query }
       end
 
       context 'complex SELECT statement' do
-        let(:query) { 'SELECT "memory_total_bytes", "memory_swap_total_bytes" - "memory_swap_free_bytes" AS swap, date_part(?, "s"."collected_at") AS collected_at FROM snapshots s JOIN system_snapshots ON "snapshot_id" = "s"."id" WHERE "s"."database_id" = ? AND "s"."collected_at" >= ? AND "s"."collected_at" <= ? ORDER BY "collected_at" ASC' }
+        let(:query) { 'SELECT "memory_total_bytes", "memory_swap_total_bytes" - "memory_swap_free_bytes" AS swap, date_part(?, "s"."collected_at") AS collected_at FROM "snapshots" s JOIN "system_snapshots" ON "snapshot_id" = "s"."id" WHERE "s"."database_id" = ? AND "s"."collected_at" >= ? AND "s"."collected_at" <= ? ORDER BY "collected_at" ASC' }
         it { is_expected.to eq query }
       end
 
@@ -24,7 +24,7 @@ describe PgQuery::Deparse do
       end
 
       context 'simple WITH statement' do
-        let(:query) { 'WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM t' }
+        let(:query) { 'WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM "t"' }
         it { is_expected.to eq query }
       end
 
@@ -36,27 +36,27 @@ describe PgQuery::Deparse do
               SELECT "g"."id", "g"."link", "g"."data", 1,
                 ARRAY[ROW("g"."f1", "g"."f2")],
                 false
-              FROM graph g
+              FROM "graph" g
             UNION ALL
               SELECT "g"."id", "g"."link", "g"."data", "sg"."depth" + 1,
                 "path" || ROW("g"."f1", "g"."f2"),
                 ROW("g"."f1", "g"."f2") = ANY("path")
-              FROM graph g, search_graph sg
+              FROM "graph" g, "search_graph" sg
               WHERE "g"."id" = "sg"."link" AND NOT "cycle"
           )
-          SELECT "id", "data", "link" FROM search_graph;
+          SELECT "id", "data", "link" FROM "search_graph";
           '''
         end
         it { is_expected.to eq oneline_query }
       end
 
       context 'SUM' do
-        let(:query) { 'SELECT sum("price_cents") FROM products' }
+        let(:query) { 'SELECT sum("price_cents") FROM "products"' }
         it { is_expected.to eq query }
       end
 
       context 'LATERAL' do
-        let(:query) { 'SELECT "m"."name" AS mname, "pname" FROM manufacturers m, LATERAL get_product_names("m"."id") pname' }
+        let(:query) { 'SELECT "m"."name" AS mname, "pname" FROM "manufacturers" m, LATERAL get_product_names("m"."id") pname' }
         it { is_expected.to eq query }
       end
 
@@ -64,7 +64,7 @@ describe PgQuery::Deparse do
         let(:query) do
           '''
           SELECT "m"."name" AS mname, "pname"
-            FROM manufacturers m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true
+            FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true
           '''
         end
         it { is_expected.to eq oneline_query }
@@ -72,7 +72,7 @@ describe PgQuery::Deparse do
 
       context 'CROSS JOIN' do
         let(:query) do
-          'SELECT "x", "y" FROM a CROSS JOIN b'
+          'SELECT "x", "y" FROM "a" CROSS JOIN "b"'
         end
         it { is_expected.to eq query }
       end
@@ -83,37 +83,37 @@ describe PgQuery::Deparse do
       end
 
       context 'IS NULL' do
-        let(:query) { 'SELECT * FROM x WHERE "y" IS NULL' }
+        let(:query) { 'SELECT * FROM "x" WHERE "y" IS NULL' }
         it { is_expected.to eq query }
       end
 
       context 'IS NOT NULL' do
-        let(:query) { 'SELECT * FROM x WHERE "y" IS NOT NULL' }
+        let(:query) { 'SELECT * FROM "x" WHERE "y" IS NOT NULL' }
         it { is_expected.to eq query }
       end
 
       context 'COUNT' do
-        let(:query) { 'SELECT count(*) FROM x WHERE "y" IS NOT NULL' }
+        let(:query) { 'SELECT count(*) FROM "x" WHERE "y" IS NOT NULL' }
         it { is_expected.to eq query }
       end
 
-      context 'COUNT' do
-        let(:query) { 'SELECT count(DISTINCT "a") FROM x WHERE "y" IS NOT NULL' }
+      context 'COUNT DISTINCT' do
+        let(:query) { 'SELECT count(DISTINCT "a") FROM "x" WHERE "y" IS NOT NULL' }
         it { is_expected.to eq query }
       end
 
       context 'basic CASE WHEN statements' do
-        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' END FROM accounts a' }
+        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' END FROM "accounts" a' }
         it { is_expected.to eq query }
       end
 
       context 'CASE WHEN statements with ELSE clause' do
-        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' ELSE \'unknown\' END FROM accounts a' }
+        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' ELSE \'unknown\' END FROM "accounts" a' }
         it { is_expected.to eq query }
       end
 
       context 'CASE WHEN statements in WHERE clause' do
-        let(:query) { 'SELECT * FROM accounts WHERE "status" = CASE WHEN "x" = 1 THEN \'active\' ELSE \'inactive\' END' }
+        let(:query) { 'SELECT * FROM "accounts" WHERE "status" = CASE WHEN "x" = 1 THEN \'active\' ELSE \'inactive\' END' }
         it { is_expected.to eq query }
       end
 
@@ -133,42 +133,42 @@ describe PgQuery::Deparse do
       end
 
       context 'IN expression' do
-        let(:query) { 'SELECT * FROM x WHERE "id" IN (1, 2, 3)' }
+        let(:query) { 'SELECT * FROM "x" WHERE "id" IN (1, 2, 3)' }
         it { is_expected.to eq query }
       end
 
       context 'IN expression Subselect' do
-        let(:query) { 'SELECT * FROM x WHERE "id" IN (SELECT "id" FROM account)' }
+        let(:query) { 'SELECT * FROM "x" WHERE "id" IN (SELECT "id" FROM "account")' }
         it { is_expected.to eq query }
       end
 
       context 'NOT IN expression' do
-        let(:query) { 'SELECT * FROM x WHERE "id" NOT IN (1, 2, 3)' }
+        let(:query) { 'SELECT * FROM "x" WHERE "id" NOT IN (1, 2, 3)' }
         it { is_expected.to eq query }
       end
 
       context 'Subselect JOIN' do
-        let(:query) { 'SELECT * FROM x JOIN (SELECT "n" FROM z) b ON "a"."id" = "b"."id"' }
+        let(:query) { 'SELECT * FROM "x" JOIN (SELECT "n" FROM "z") b ON "a"."id" = "b"."id"' }
         it { is_expected.to eq query }
       end
 
       context 'simple indirection' do
-        let(:query) { 'SELECT * FROM x WHERE "y" = "z"[?]' }
+        let(:query) { 'SELECT * FROM "x" WHERE "y" = "z"[?]' }
         it { is_expected.to eq query }
       end
 
       context 'complex indirection' do
-        let(:query) { 'SELECT * FROM x WHERE "y" = "z"[?][?]' }
+        let(:query) { 'SELECT * FROM "x" WHERE "y" = "z"[?][?]' }
         it { is_expected.to eq query }
       end
 
       context 'NOT' do
-        let(:query) { 'SELECT * FROM x WHERE NOT "y"' }
+        let(:query) { 'SELECT * FROM "x" WHERE NOT "y"' }
         it { is_expected.to eq query }
       end
 
       context 'OR' do
-        let(:query) { 'SELECT * FROM x WHERE "x" OR "y"' }
+        let(:query) { 'SELECT * FROM "x" WHERE "x" OR "y"' }
         it { is_expected.to eq query }
       end
 
@@ -188,27 +188,27 @@ describe PgQuery::Deparse do
       end
 
       context 'ANY' do
-        let(:query) { 'SELECT * FROM x WHERE "x" = ANY(?)' }
+        let(:query) { 'SELECT * FROM "x" WHERE "x" = ANY(?)' }
         it { is_expected.to eq query }
       end
 
       context 'COALESCE' do
-        let(:query) { 'SELECT * FROM x WHERE "x" = COALESCE("y", ?)' }
+        let(:query) { 'SELECT * FROM "x" WHERE "x" = COALESCE("y", ?)' }
         it { is_expected.to eq query }
       end
 
       context 'GROUP BY' do
-        let(:query) { 'SELECT "a", "b", max("c") FROM c WHERE "d" = 1 GROUP BY "a", "b"' }
+        let(:query) { 'SELECT "a", "b", max("c") FROM "c" WHERE "d" = 1 GROUP BY "a", "b"' }
         it { is_expected.to eq query }
       end
 
       context 'LIMIT' do
-        let(:query) { "SELECT * FROM x LIMIT 50" }
+        let(:query) { 'SELECT * FROM "x" LIMIT 50' }
         it { is_expected.to eq query }
       end
 
       context 'OFFSET' do
-        let(:query) { "SELECT * FROM x OFFSET 50" }
+        let(:query) { 'SELECT * FROM "x" OFFSET 50' }
         it { is_expected.to eq query }
       end
     end
@@ -239,12 +239,12 @@ describe PgQuery::Deparse do
 
     context 'INSERT' do
       context 'basic' do
-        let(:query) { "INSERT INTO x (y, z) VALUES (1, 'abc')" }
+        let(:query) { 'INSERT INTO "x" (y, z) VALUES (1, \'abc\')' }
         it { is_expected.to eq query }
       end
 
       context 'INTO SELECT' do
-        let(:query) { "INSERT INTO x SELECT * FROM y" }
+        let(:query) { 'INSERT INTO "x" SELECT * FROM "y"' }
         it { is_expected.to eq query }
       end
 
@@ -253,11 +253,11 @@ describe PgQuery::Deparse do
           '''
           WITH moved AS (
             DELETE
-            FROM employees
+            FROM "employees"
             WHERE "manager_name" = \'Mary\'
           )
-          INSERT INTO employees_of_mary
-          SELECT * FROM moved;
+          INSERT INTO "employees_of_mary"
+          SELECT * FROM "moved";
           '''
         end
         it { is_expected.to eq oneline_query }
@@ -266,8 +266,8 @@ describe PgQuery::Deparse do
       context 'HAVING' do
         let(:query) do
           '''
-          INSERT INTO employees
-          SELECT * FROM people
+          INSERT INTO "employees"
+          SELECT * FROM "people"
           WHERE 1 = 1
           GROUP BY "name"
           HAVING count("name") > 1
@@ -283,7 +283,7 @@ describe PgQuery::Deparse do
       context 'with locks' do
         let(:query) do
           '''
-          SELECT * FROM people FOR UPDATE OF name, email
+          SELECT * FROM "people" FOR UPDATE OF "name", "email"
           '''
         end
         it { is_expected.to eq oneline_query }
@@ -292,13 +292,13 @@ describe PgQuery::Deparse do
 
     context 'UPDATE' do
       context 'basic' do
-        let(:query) { 'UPDATE x SET y = 1 WHERE "z" = \'abc\'' }
+        let(:query) { 'UPDATE "x" SET y = 1 WHERE "z" = \'abc\'' }
         it { is_expected.to eq query }
       end
 
       context 'elaborate' do
         let(:query) do
-          'UPDATE ONLY x table_x SET y = 1 WHERE "z" = \'abc\' RETURNING "y" AS changed_y'
+          'UPDATE ONLY "x" table_x SET y = 1 WHERE "z" = \'abc\' RETURNING "y" AS changed_y'
         end
         it { is_expected.to eq query }
       end
@@ -308,10 +308,10 @@ describe PgQuery::Deparse do
           '''
           WITH archived AS (
             DELETE
-            FROM employees
+            FROM "employees"
             WHERE "manager_name" = \'Mary\'
           )
-          UPDATE users SET archived = true WHERE "users"."id" IN (SELECT "user_id" FROM moved)
+          UPDATE "users" SET archived = true WHERE "users"."id" IN (SELECT "user_id" FROM "moved")
           '''
         end
         it { is_expected.to eq oneline_query }
@@ -320,7 +320,7 @@ describe PgQuery::Deparse do
       context 'from generated sequence' do
         let(:query) do
           '''
-            INSERT INTO jackdanger_card_totals (id, amount_cents, created_at)
+            INSERT INTO "jackdanger_card_totals" (id, amount_cents, created_at)
             SELECT
               "series"."i",
               random() * 1000,
@@ -336,12 +336,12 @@ describe PgQuery::Deparse do
 
     context 'DELETE' do
       context 'basic' do
-        let(:query) { 'DELETE FROM x WHERE "y" = 1' }
+        let(:query) { 'DELETE FROM "x" WHERE "y" = 1' }
         it { is_expected.to eq query }
       end
 
       context 'elaborate' do
-        let(:query) { 'DELETE FROM ONLY x table_x USING table_z WHERE "y" = 1 RETURNING *' }
+        let(:query) { 'DELETE FROM ONLY "x" table_x USING "table_z" WHERE "y" = 1 RETURNING *' }
         it { is_expected.to eq query }
       end
 
@@ -350,10 +350,10 @@ describe PgQuery::Deparse do
           '''
           WITH archived AS (
             DELETE
-            FROM employees
+            FROM "employees"
             WHERE "manager_name" = \'Mary\'
           )
-          DELETE FROM users WHERE "users"."id" IN (SELECT "user_id" FROM moved)
+          DELETE FROM "users" WHERE "users"."id" IN (SELECT "user_id" FROM "moved")
           '''
         end
         it { is_expected.to eq oneline_query }
@@ -364,11 +364,11 @@ describe PgQuery::Deparse do
       # Taken from http://www.postgresql.org/docs/8.3/static/queries-table-expressions.html
       context 'with inline function definition' do
         let(:query) do
-          """
+          '''
           CREATE FUNCTION getfoo(int) RETURNS SETOF users AS $$
-              SELECT * FROM users WHERE users.id = $1;
+              SELECT * FROM "users" WHERE users.id = $1;
           $$ language sql
-          """.strip
+          '''.strip
         end
         it { is_expected.to eq query }
       end
@@ -377,8 +377,8 @@ describe PgQuery::Deparse do
     context 'CREATE TABLE' do
       context 'top-level' do
         let(:query) do
-          """
-            CREATE UNLOGGED TABLE cities (
+          '''
+            CREATE UNLOGGED TABLE "cities" (
                 name            text,
                 population      real,
                 altitude        double,
@@ -386,26 +386,26 @@ describe PgQuery::Deparse do
                 postal_code     int,
                 foreign_id      bigint
            );
-          """
+          '''
         end
         it { is_expected.to eq oneline_query }
       end
 
       context 'with common types' do
         let(:query) do
-          """
-            CREATE TABLE IF NOT EXISTS distributors (
-                name       varchar(40) DEFAULT 'Luso Films',
+          '''
+            CREATE TABLE IF NOT EXISTS "distributors" (
+                name       varchar(40) DEFAULT \'Luso Films\',
                 len        interval hour to second(3),
-                name       varchar(40) DEFAULT 'Luso Films',
-                did        int DEFAULT nextval('distributors_serial'),
+                name       varchar(40) DEFAULT \'Luso Films\',
+                did        int DEFAULT nextval(\'distributors_serial\'),
                 stamp      timestamp DEFAULT now() NOT NULL,
                 stamptz    timestamp with time zone,
                 time       time NOT NULL,
                 timetz     time with time zone,
                 CONSTRAINT name_len PRIMARY KEY (name, len)
             );
-          """
+          '''
         end
         it { is_expected.to eq oneline_query }
       end
@@ -418,29 +418,29 @@ describe PgQuery::Deparse do
         end
         it do
           is_expected.to eq(
-            "CREATE TABLE types (a real, b double, c numeric(2, 3), d char(4), e char(5), f varchar(6), g varchar(7))"
+            'CREATE TABLE "types" (a real, b double, c numeric(2, 3), d char(4), e char(5), f varchar(6), g varchar(7))'
           )
         end
       end
 
       context 'with column definition options' do
         let(:query) do
-          """
-          CREATE TABLE tablename (
-              colname int NOT NULL DEFAULT nextval('tablename_colname_seq')
+          '''
+          CREATE TABLE "tablename" (
+              colname int NOT NULL DEFAULT nextval(\'tablename_colname_seq\')
           );
-          """
+          '''
         end
         it { is_expected.to eq oneline_query }
       end
 
       context 'inheriting' do
         let(:query) do
-          """
-            CREATE TABLE capitals (
+          '''
+            CREATE TABLE "capitals" (
                 state           char(2)
-            ) INHERITS (cities);
-          """
+            ) INHERITS ("cities");
+          '''
         end
         it { is_expected.to eq oneline_query }
       end
@@ -462,7 +462,7 @@ describe PgQuery::Deparse do
       context 'with column modifications' do
         let(:query) do
           '''
-          ALTER TABLE distributors
+          ALTER TABLE "distributors"
             DROP CONSTRAINT distributors_pkey,
             ADD CONSTRAINT distributors_pkey PRIMARY KEY USING INDEX dist_id_temp_idx,
             ADD CONSTRAINT zipchk CHECK (char_length("zipcode") = 5),
@@ -480,7 +480,7 @@ describe PgQuery::Deparse do
       end
 
       context 'rename' do
-        let(:query) { 'ALTER TABLE distributors RENAME TO suppliers;' }
+        let(:query) { 'ALTER TABLE "distributors" RENAME TO suppliers;' }
         it { is_expected.to eq oneline_query }
       end
     end
@@ -519,13 +519,13 @@ describe PgQuery::Deparse do
 
     context 'COMMENTS' do
       let(:query) do
-        """
-        CREATE TABLE remove_comments (
+        '''
+        CREATE TABLE "remove_comments" (
           id int -- inline comment in multiline
         );
-        """
+        '''
       end
-      it { is_expected.to eq("CREATE TABLE remove_comments (id int)") }
+      it { is_expected.to eq('CREATE TABLE "remove_comments" (id int)') }
     end
 
     context 'OVER' do
@@ -558,7 +558,7 @@ describe PgQuery::Deparse do
 
       context 'recursive' do
         let(:shorthand_query) { 'CREATE RECURSIVE VIEW view_a (a, b) AS SELECT * FROM a(1)' }
-        let(:query) { 'CREATE VIEW view_a (a, b) AS WITH RECURSIVE view_a (a, b) AS (SELECT * FROM a(1)) SELECT "a", "b" FROM view_a' }
+        let(:query) { 'CREATE VIEW view_a (a, b) AS WITH RECURSIVE view_a (a, b) AS (SELECT * FROM a(1)) SELECT "a", "b" FROM "view_a"' }
 
         it 'parses both and deparses into the normalized form' do
           expect(described_class.from(PgQuery.parse(query).parsetree.first)).to eq(query)
@@ -575,7 +575,7 @@ describe PgQuery::Deparse do
       let(:query) do
         '''
         SELECT "m"."name" AS mname, "pname"
-          FROM manufacturers m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true
+          FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true
         '''
       end
       it { is_expected.to eq oneline_query }
@@ -585,9 +585,9 @@ describe PgQuery::Deparse do
       let(:query) do
         '''
         SELECT "m"."name" AS mname, "pname"
-          FROM manufacturers m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true;
-        INSERT INTO manufacturers_daily (a, b)
-          SELECT "a", "b" FROM manufacturers;
+          FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true;
+        INSERT INTO "manufacturers_daily" (a, b)
+          SELECT "a", "b" FROM "manufacturers";
         '''
       end
       it { is_expected.to eq oneline_query }
@@ -597,10 +597,10 @@ describe PgQuery::Deparse do
       let(:query) do
         '''
         SELECT "m"."name" AS mname, "pname"
-          FROM manufacturers m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true;
-        UPDATE users SET name = \'bobby; drop tables\';
-        INSERT INTO manufacturers_daily (a, b)
-          SELECT "a", "b" FROM manufacturers;
+          FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true;
+        UPDATE "users" SET name = \'bobby; drop tables\';
+        INSERT INTO "manufacturers_daily" (a, b)
+          SELECT "a", "b" FROM "manufacturers";
         '''
       end
       it { is_expected.to eq oneline_query }

--- a/spec/lib/truncate_spec.rb
+++ b/spec/lib/truncate_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 describe PgQuery, '#truncate' do
   it 'omits target list' do
     query = 'SELECT a, b, c, d, e, f FROM xyz WHERE a = b'
-    expect(described_class.parse(query).truncate(40)).to eq 'SELECT ... FROM xyz WHERE "a" = "b"'
+    expect(described_class.parse(query).truncate(40)).to eq 'SELECT ... FROM "xyz" WHERE "a" = "b"'
   end
 
   it 'omits with part of CTEs' do
     query = 'WITH x AS (SELECT * FROM y) SELECT * FROM x'
-    expect(described_class.parse(query).truncate(40)).to eq 'WITH x AS (...) SELECT * FROM x'
+    expect(described_class.parse(query).truncate(40)).to eq 'WITH x AS (...) SELECT * FROM "x"'
   end
 
   it 'omits where clause' do
     query = 'SELECT * FROM z WHERE a = b AND x = y'
-    expect(described_class.parse(query).truncate(30)).to eq 'SELECT * FROM z WHERE ...'
+    expect(described_class.parse(query).truncate(30)).to eq 'SELECT * FROM "z" WHERE ...'
   end
 
   it 'omits INSERT field list' do
-    query = 'INSERT INTO x (a, b, c, d, e, f) VALUES (?)'
-    expect(described_class.parse(query).truncate(30)).to eq 'INSERT INTO x (...) VALUES (?)'
+    query = 'INSERT INTO "x" (a, b, c, d, e, f) VALUES (?)'
+    expect(described_class.parse(query).truncate(32)).to eq 'INSERT INTO "x" (...) VALUES (?)'
   end
 
   it 'performs a simple truncation if necessary' do


### PR DESCRIPTION
Similar to #40 . Currently, deparsing special/unsupported from clauses results in incorrect SQL code:

```sql
select * from "hello-world"
```

will deparse into

```sql
select * from hello-world
```

Where the dash is unsupported. 

Fixed by quoting all rangevars.