### PR TITLE
Include columns with boolean tests in filter_expression output

### DIFF
--- a/lib/pg_query/filter_columns.rb
+++ b/lib/pg_query/filter_columns.rb
@@ -64,6 +64,8 @@ class PgQuery
           filter_columns << [@aliases[table] || table, column]
         elsif next_item[NULL_TEST]
           condition_items << next_item[NULL_TEST]['arg']
+        elsif next_item[BOOLEAN_TEST]
+          condition_items << next_item[BOOLEAN_TEST]['arg']
         elsif next_item[FUNC_CALL]
           # FIXME: This should actually be extracted as a funccall and be compared with those indices
           condition_items += next_item[FUNC_CALL]['args'] if next_item[FUNC_CALL]['args']

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -14,6 +14,7 @@ class PgQuery
   ALTER_TABLE_STMT = 'AlterTableStmt'.freeze
   BIT_STRING = 'BitString'.freeze
   BOOL_EXPR = 'BoolExpr'.freeze
+  BOOLEAN_TEST = 'BooleanTest'.freeze
   CASE_EXPR = 'CaseExpr'.freeze
   CASE_WHEN = 'CaseWhen'.freeze
   CHECK_POINT_STMT = 'CheckPointStmt'.freeze

--- a/spec/lib/filter_columns_spec.rb
+++ b/spec/lib/filter_columns_spec.rb
@@ -18,4 +18,8 @@ describe PgQuery, '#filter_columns' do
     query = 'WITH a AS (SELECT * FROM x WHERE x.y = ? AND x.z = 1) SELECT * FROM a WHERE b = 5'
     expect(filter_columns(query)).to match_array [['x', 'y'], ['x', 'z'], [nil, 'b']]
   end
+
+  it 'recognizes boolean tests' do
+    expect(filter_columns('SELECT * FROM x WHERE x.y IS TRUE AND x.z IS NOT FALSE')).to eq [['x', 'y'], ['x', 'z']]
+  end
 end


### PR DESCRIPTION
Currently columns with IS true/false or IS NOT true/false are ignored in filter_expression output. Since we are including tests for IS null, it seems reasonable to include the boolean tests as well.
