### PR TITLE
Enable SET deparsing

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -136,6 +136,8 @@ class PgQuery
         deparse_with_clause(node)
       when VIEW_STMT
         deparse_viewstmt(node)
+      when VARIABLE_SET_STMT
+        deparse_variable_set_stmt(node)
       when STRING
         if context == A_CONST
           format("'%s'", node['str'].gsub("'", "''"))
@@ -437,6 +439,16 @@ class PgQuery
       when 2
         output << 'WITH CASCADED CHECK OPTION'
       end
+      output.join(' ')
+    end
+
+    def deparse_variable_set_stmt(node)
+      output = []
+      output << "SET"
+      output << "LOCAL" if node["is_local"]
+      output << node['name']
+      output << "TO"
+      output << node['args'].map { |arg| deparse_item(arg) }.join(', ')
       output.join(' ')
     end
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -566,6 +566,43 @@ describe PgQuery::Deparse do
         end
       end
     end
+
+    context 'SET' do
+      context 'with integer value' do
+        let(:query) do
+          '''
+          SET statement_timeout TO 10000;
+          '''
+        end
+        it { is_expected.to eq oneline_query }
+      end
+      context 'with string value' do
+        let(:query) do
+          '''
+          SET search_path TO \'my_schema\', \'public\';
+          '''
+        end
+        it { is_expected.to eq oneline_query }
+      end
+      context 'with local scope' do
+        let(:query) do
+          '''
+          SET LOCAL search_path TO \'my_schema\', \'public\';
+          '''
+        end
+        it { is_expected.to eq oneline_query }
+      end
+      # Because SESSION is default, it is removed by the query parser.
+      context 'with session scope' do
+        let(:query) do
+          '''
+          SET SESSION search_path TO 10000;
+          '''
+        end
+        it { is_expected.to eq "SET search_path TO 10000" }
+      end
+    end
+
   end
 
   describe '#deparse' do


### PR DESCRIPTION
Enables set command deparsing for commands like:

```sql
SET statement_timeout TO 10000;
SET LOCAL statement_timeout TO 10000;
SET schema_path TO 'public','production';
```