### PR TITLE
LIKE / NOT LIKE to work with deparser

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -36,6 +36,8 @@ class PgQuery
           deparse_aexpr_any(node)
         when AEXPR_IN
           deparse_aexpr_in(node)
+        when CONSTR_TYPE_FOREIGN
+          deparse_aexpr_like(node)
         else
           fail format("Can't deparse: %s: %s", type, node.inspect)
         end
@@ -310,6 +312,12 @@ class PgQuery
       rexpr = Array(node['rexpr']).map { |arg| deparse_item(arg) }
       operator = node['name'].map { |n| deparse_item(n, :operator) } == ['='] ? 'IN' : 'NOT IN'
       format('%s %s (%s)', deparse_item(node['lexpr']), operator, rexpr.join(', '))
+    end
+
+    def deparse_aexpr_like(node)
+      value = deparse_item(node['rexpr'])
+      operator = node['name'].map { |n| deparse_item(n, :operator) } == ['~~'] ? 'LIKE' : 'NOT LIKE'
+      format('%s %s %s', deparse_item(node['lexpr']), operator, value)
     end
 
     def deparse_bool_expr_not(node)

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -23,6 +23,16 @@ describe PgQuery::Deparse do
         it { is_expected.to eq oneline_query }
       end
 
+      context 'with LIKE filter' do
+        let(:query) { "SELECT * FROM \"users\" WHERE \"name\" LIKE 'postgresql:%';" }
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with NOT LIKE filter' do
+        let(:query) { "SELECT * FROM \"users\" WHERE \"name\" NOT LIKE 'postgresql:%';" }
+        it { is_expected.to eq oneline_query }
+      end
+
       context 'simple WITH statement' do
         let(:query) { 'WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM "t"' }
         it { is_expected.to eq query }


### PR DESCRIPTION
Enable deparser with statements like:

```sql
SELECT * FROM "users" WHERE "name" LIKE 'postgresql:%';
SELECT * FROM "users" WHERE "name" NOT LIKE 'postgresql:%';
```