### PR TITLE
Add commonly used function uses

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -532,7 +532,9 @@ class PgQuery
 
     def deparse_create_function(node)
       output = []
-      output << 'CREATE FUNCTION'
+      output << 'CREATE'
+      output << 'OR REPLACE' if node['replace']
+      output << 'FUNCTION'
 
       arguments = deparse_item_list(node['parameters']).join(', ')
 
@@ -856,6 +858,10 @@ class PgQuery
         "AS $$#{deparse_item_list(node['arg'], :defname_as).join("\n")}$$"
       when 'language'
         "language #{deparse_item(node['arg'])}"
+      when 'volatility'
+        node['arg']['String']['str'].upcase # volatility does not need to be quoted
+      when 'strict'
+        deparse_item(node['arg']) == '1' ? 'RETURNS NULL ON NULL INPUT' : 'CALLED ON NULL INPUT'
       else
         deparse_item(node['arg'])
       end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -382,6 +382,50 @@ describe PgQuery::Deparse do
         end
         it { is_expected.to eq query }
       end
+
+      context 'with or replace' do
+        let(:query) do
+          """
+          CREATE OR REPLACE FUNCTION \"getfoo\"(int) RETURNS SETOF users AS $$
+              SELECT * FROM \"users\" WHERE users.id = $1;
+          $$ language \"sql\"
+          """.strip
+        end
+        it { is_expected.to eq query }
+      end
+
+      context 'with immutable' do
+        let(:query) do
+          """
+          CREATE OR REPLACE FUNCTION \"getfoo\"(int) RETURNS SETOF users AS $$
+              SELECT * FROM \"users\" WHERE users.id = $1;
+          $$ language \"sql\" IMMUTABLE
+          """.strip
+        end
+        it { is_expected.to eq query }
+      end
+
+      context 'with STRICT (aka return null on null input)' do
+        let(:query) do
+          """
+          CREATE OR REPLACE FUNCTION \"getfoo\"(int) RETURNS SETOF users AS $$
+              SELECT * FROM \"users\" WHERE users.id = $1;
+          $$ language \"sql\" IMMUTABLE RETURNS NULL ON NULL INPUT
+          """.strip
+        end
+        it { is_expected.to eq query }
+      end
+
+      context 'with called on null input' do
+        let(:query) do
+          """
+          CREATE OR REPLACE FUNCTION \"getfoo\"(int) RETURNS SETOF users AS $$
+              SELECT * FROM \"users\" WHERE users.id = $1;
+          $$ language \"sql\" IMMUTABLE CALLED ON NULL INPUT
+          """.strip
+        end
+        it { is_expected.to eq query }
+      end
     end
 
     context 'CREATE TABLE' do


### PR DESCRIPTION
This implementation allows for the following on function initialization:

* use `CREATE OR REPLACE FUNCTION` where previously, on `CREATE FUNCTION` worked
* remove quotes characters `"` from around statements for volatility (i.e. `IMMUTABLE` instead of `"IMMUTABLE"`)
* accept statements of strictness on functions (i.e. `RETURNS NULL ON NULL INPUT`)