### PR TITLE
enable REFERENCES on ALTER TABLE FOREIGN KEY deparsing

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -526,6 +526,9 @@ class PgQuery
         output << expression
       end
       output << '(' + deparse_item_list(node['keys']).join(', ') + ')' if node['keys']
+      output << '(' + deparse_item_list(node['fk_attrs']).join(', ') + ')' if node['fk_attrs']
+      output << 'REFERENCES ' + deparse_item(node['pktable']) + ' (' + deparse_item_list(node['pk_attrs']).join(', ') + ')' if node['pktable']
+      output << 'NOT VALID' if node['skip_validation']
       output << "USING INDEX #{node['indexname']}" if node['indexname']
       output.join(' ')
     end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -537,6 +537,16 @@ describe PgQuery::Deparse do
         let(:query) { 'ALTER TABLE "distributors" RENAME TO suppliers;' }
         it { is_expected.to eq oneline_query }
       end
+
+      context 'FOREIGN KEY' do
+        let(:query) { 'ALTER TABLE "distributors" ADD CONSTRAINT distfk FOREIGN KEY ("address") REFERENCES "addresses" ("address");' }
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'FOREIGN KEY NOT VALID' do
+        let(:query) { 'ALTER TABLE "distributors" ADD CONSTRAINT distfk FOREIGN KEY ("address") REFERENCES "addresses" ("address") NOT VALID;' }
+        it { is_expected.to eq oneline_query }
+      end
     end
 
     context 'TRANSACTION' do


### PR DESCRIPTION
When using `ALTER TABLE`, the `REFERENCES` keyword was not working.  This fixes queries like the following:

```sql
ALTER TABLE "distributors" ADD CONSTRAINT distfk FOREIGN KEY ("address") REFERENCES "addresses" ("address");
ALTER TABLE "distributors" ADD CONSTRAINT distfk FOREIGN KEY ("address") REFERENCES "addresses" ("address") NOT NULL;
```