### PR TITLE
Deparse Float.

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -150,6 +150,8 @@ class PgQuery
         end
       when INTEGER
         node['ival'].to_s
+      when FLOAT
+        node['str']
       else
         fail format("Can't deparse: %s: %s", type, node.inspect)
       end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -221,6 +221,11 @@ describe PgQuery::Deparse do
         let(:query) { 'SELECT * FROM "x" OFFSET 50' }
         it { is_expected.to eq query }
       end
+
+      context 'FLOAT' do
+        let(:query) { 'SELECT "amount" * 0.5' }
+        it { is_expected.to eq query }
+      end
     end
 
     context 'type cast' do


### PR DESCRIPTION
This fixes a problem with deparsing a Float in a SELECT clause - something like "SELECT amount * 0.5 FROM xyz".