### PR TITLE
Fix build on BSD systems

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -24,7 +24,7 @@ end
 
 unless Dir.exist?(libfile)
   # Build libpg_query (and parts of PostgreSQL)
-  system("cd #{libdir}; make build")
+  system("cd #{libdir}; #{ENV['MAKE'] || (RUBY_PLATFORM =~ /bsd/ ? 'gmake' : 'make')} build")
 end
 
 # Copy test files (this intentionally overwrites existing files!)


### PR DESCRIPTION
I guess there might be a better way to run the same `make` that `create_makefile` runs?? But this will do.