### PR TITLE
Deparse varchar and numeric casts without arguments.

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -817,10 +817,10 @@ class PgQuery
         # char(2) or char(9)
         "char(#{arguments})"
       when 'varchar'
-        "varchar(#{arguments})"
+        arguments.nil? ? 'varchar' : "varchar(#{arguments})"
       when 'numeric'
         # numeric(3, 5)
-        "numeric(#{arguments})"
+        arguments.nil? ? 'numeric' : "numeric(#{arguments})"
       when 'bool'
         'boolean'
       when 'int2'

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -363,6 +363,42 @@ describe PgQuery::Deparse do
         end
         it { is_expected.to eq oneline_query }
       end
+
+      context 'with cast varchar' do
+        let(:query) do
+          '''
+          SELECT "name"::varchar(255) FROM "people"
+          '''
+        end
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with cast varchar and no arguments' do
+        let(:query) do
+          '''
+          SELECT "name"::varchar FROM "people"
+          '''
+        end
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with cast numeric' do
+        let(:query) do
+          '''
+          SELECT "age"::numeric(5, 2) FROM "people"
+          '''
+        end
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with cast numeric and no arguments' do
+        let(:query) do
+          '''
+          SELECT "age"::numeric FROM "people"
+          '''
+        end
+        it { is_expected.to eq oneline_query }
+      end
     end
 
     context 'UPDATE' do


### PR DESCRIPTION
When no arguments were supplied when casting to varchar or numeric, deparse was returning `()`.
e.g.
`CAST("name" AS VARCHAR(255))` or `"name"::varchar` were deparsed as `"name"::varchar()`.

This change returns `"name"::varchar` in this case and does similar for `numeric`.
