### PR TITLE
Use Integer class for checking integer instead of Fixnum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ rvm:
  - 2.1.8
  - 2.2.4
  - 2.3.0
+ - 2.4.0
 script: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
     diff-lcs (1.2.5)
-    json (1.8.3)
+    json (2.0.3)
     parser (2.2.2.5)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -22,7 +22,7 @@ class PgQuery
 
     def deparse_item(item, context = nil) # rubocop:disable Metrics/CyclomaticComplexity
       return if item.nil?
-      return item if item.is_a?(Fixnum)
+      return item if item.is_a?(Integer)
 
       type = item.keys[0]
       node = item.values[0]


### PR DESCRIPTION
Since Fixnum and Bignum are unfied into Integer in Ruby 2.4+, a warning
occurs for using Fixnum (or Bignum).