### PR TITLE
Deparse coldeflist.

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -353,6 +353,7 @@ class PgQuery
       output << 'LATERAL' if node['lateral']
       output << deparse_item(node['functions'][0][0]) # FIXME: Needs more test cases
       output << deparse_item(node['alias']) if node['alias']
+      output << "#{node['alias'] ? '' : 'AS '}(#{deparse_item_list(node['coldeflist']).join(', ')})" if node['coldeflist']
       output.join(' ')
     end
 
@@ -801,6 +802,7 @@ class PgQuery
         end.join(', ')
       end
       output << deparse_typename_cast(names, arguments)
+      output.last << '[]' if node['arrayBounds']
 
       output.join(' ')
     end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -286,6 +286,42 @@ describe PgQuery::Deparse do
         let(:query) { 'SELECT * FROM "x" WHERE "y" IS NOT UNKNOWN' }
         it { is_expected.to eq query }
       end
+
+      context 'with columndef list' do
+        let(:query) do
+          %q{
+          SELECT * FROM crosstab(
+          'SELECT "department", "role", COUNT("id") FROM "users" GROUP BY "department", "role" ORDER BY "department", "role"',
+          'VALUES (''admin''::text), (''ordinary''::text)')
+          AS (department varchar, admin int, ordinary int)
+          }
+        end
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with columndef list and alias' do
+        let(:query) do
+          %q{
+          SELECT * FROM crosstab(
+          'SELECT "department", "role", COUNT("id") FROM "users" GROUP BY "department", "role" ORDER BY "department", "role"',
+          'VALUES (''admin''::text), (''ordinary''::text)')
+          ctab (department varchar, admin int, ordinary int)
+          }
+        end
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with columndef list returning an array' do
+        let(:query) do
+          %q{
+          SELECT "row_cols"[0] AS dept, "row_cols"[1] AS sub, "admin", "ordinary" FROM crosstab(
+          'SELECT ARRAY["department", "sub"] AS row_cols, "role", COUNT("id") FROM "users" GROUP BY "department", "role" ORDER BY "department", "role"',
+          'VALUES (''admin''::text), (''ordinary''::text)')
+          AS (row_cols varchar[], admin int, ordinary int)
+          }
+        end
+        it { is_expected.to eq oneline_query }
+      end
     end
 
     context 'type cast' do


### PR DESCRIPTION
Deparse coldeflist.

(Includes a fix to `deparse_typename` so it returns `varchar[]` when required instead of just `varchar`.)

An example of coldeflist column definitions can be seen in the last line of this crosstab query:
~~~sql
SELECT * FROM crosstab(
'SELECT "department", "role", COUNT("id") FROM "users" GROUP BY "department", "role" ORDER BY "department", "role"',
'VALUES (''admin''::text), (''ordinary''::text)')
AS (department varchar, admin int, ordinary int)
~~~