### PR TITLE
Distinguish between different types of table access (viewing, modifying, performing administration)

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -54,7 +54,7 @@ class PgQuery
     load_tables_and_aliases! if @aliases.nil?
     @aliases
   end
-  
+
   def tables_with_types
     load_tables_and_aliases! if @tables.nil?
     @tables

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -34,7 +34,7 @@ class PgQuery
   end
   
   def viewed_tables
-    tables_with_types.select { |t| t[:type] == :viewed }.map { |t| t[:table] } 
+    tables_with_types.select { |t| t[:type] == :viewed }.map { |t| t[:table] }
   end
   
   def modified_tables
@@ -102,7 +102,7 @@ class PgQuery
             statements << statement[SELECT_STMT]['rarg'] if statement[SELECT_STMT]['rarg']
           end
         # The following statements modify the contents of a table
-        when INSERT_STMT, UPDATE_STMT, DELETE_STMT, COPY_STMT, ALTER_TABLE_STMT, CREATE_STMT 
+        when INSERT_STMT, UPDATE_STMT, DELETE_STMT, COPY_STMT, ALTER_TABLE_STMT, CREATE_STMT
           from_clause_items << { item: statement.values[0]['relation'], type: :modified }
         when CREATE_TABLE_AS_STMT
           if statement[CREATE_TABLE_AS_STMT]['into'] && statement[CREATE_TABLE_AS_STMT]['into'][INTO_CLAUSE]['rel']
@@ -114,7 +114,7 @@ class PgQuery
         when REFRESH_MAT_VIEW_STMT
           from_clause_items << { item: statement[REFRESH_MAT_VIEW_STMT]['relation'], type: :modified }
         when TRUNCATE_STMT
-          from_clause_items += statement.values[0]['relations'].map {|r| { item: r, type: :modified } }
+          from_clause_items += statement.values[0]['relations'].map { |r| { item: r, type: :modified } }
         when DROP_STMT
           objects = statement[DROP_STMT]['objects'].map { |list| list.map { |obj| obj['String'] && obj['String']['str'] } }
           case statement[DROP_STMT]['removeType']
@@ -129,14 +129,14 @@ class PgQuery
         when EXPLAIN_STMT
           statements << statement[EXPLAIN_STMT]['query']
         when LOCK_STMT
-          from_clause_items += statement.values[0]['relations'].map {|r| { item: r, type: :administered } }
+          from_clause_items += statement.values[0]['relations'].map { |r| { item: r, type: :administered } }
         when GRANT_STMT
           objects = statement[GRANT_STMT]['objects']
           case statement[GRANT_STMT]['objtype']
           when 0 # Column # rubocop:disable Lint/EmptyWhen
             # FIXME
           when 1 # Table
-            from_clause_items += objects.map {|o| { item: o, type: :administered } }
+            from_clause_items += objects.map { |o| { item: o, type: :administered } }
           when 2 # Sequence # rubocop:disable Lint/EmptyWhen
             # FIXME
           end
@@ -187,7 +187,7 @@ class PgQuery
           from_clause_items << { item: next_item[:item][JOIN_EXPR][side], type: next_item[:type] }
         end
       when ROW_EXPR
-        from_clause_items += next_item[:item][ROW_EXPR]['args'].map {|a| { item: a, type: next_item[:type] } }
+        from_clause_items += next_item[:item][ROW_EXPR]['args'].map { |a| { item: a, type: next_item[:type] } }
       when RANGE_VAR
         rangevar = next_item[:item][RANGE_VAR]
         next if !rangevar['schemaname'] && @cte_names.include?(rangevar['relname'])

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -54,13 +54,13 @@ class PgQuery
     load_tables_and_aliases! if @aliases.nil?
     @aliases
   end
-
-  protected
-
+  
   def tables_with_types
     load_tables_and_aliases! if @tables.nil?
     @tables
   end
+
+  protected
 
   def load_tables_and_aliases! # rubocop:disable Metrics/CyclomaticComplexity
     @tables = [] # types: modified, viewed, administered

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -32,15 +32,15 @@ class PgQuery
   def tables
     tables_with_types.map { |t| t[:table] }
   end
-  
+
   def viewed_tables
     tables_with_types.select { |t| t[:type] == :viewed }.map { |t| t[:table] }
   end
-  
+
   def modified_tables
     tables_with_types.select { |t| t[:type] == :modified }.map { |t| t[:table] }
   end
-  
+
   def administered_tables
     tables_with_types.select { |t| t[:type] == :administered }.map { |t| t[:table] }
   end
@@ -56,7 +56,7 @@ class PgQuery
   end
 
   protected
-  
+
   def tables_with_types
     load_tables_and_aliases! if @tables.nil?
     @tables

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -18,6 +18,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse("SELECT memory_total_bytes, memory_free_bytes, memory_pagecache_bytes, memory_buffers_bytes, memory_applications_bytes, (memory_swap_total_bytes - memory_swap_free_bytes) AS swap, date_part($0, s.collected_at) AS collected_at FROM snapshots s JOIN system_snapshots ON (snapshot_id = s.id) WHERE s.database_id = $0 AND s.collected_at BETWEEN $0 AND $0 ORDER BY collected_at")
     expect(query.tree).not_to be_nil
     expect(query.tables).to eq ['snapshots', 'system_snapshots']
+    expect(query.viewed_tables).to eq ['snapshots', 'system_snapshots']
   end
 
   it "parses empty queries" do
@@ -55,6 +56,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse("ALTER TABLE test ADD PRIMARY KEY (gid)")
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['test']
+    expect(query.modified_tables).to eq ['test']
     expect(query.tree).to eq [{described_class::ALTER_TABLE_STMT=>
           {"relation"=>
             {described_class::RANGE_VAR=>
@@ -109,6 +111,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse("drop table abc.test123 cascade")
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['abc.test123']
+    expect(query.modified_tables).to eq ['abc.test123']
     expect(query.tree).to eq [{described_class::DROP_STMT=>
           {"objects"=>[[{"String"=>{"str"=>"abc"}}, {"String"=>{"str"=>"test123"}}]],
            "removeType"=>described_class::OBJECT_TYPE_TABLE,
@@ -131,6 +134,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse("VACUUM my_table")
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['my_table']
+    expect(query.administered_tables).to eq ['my_table']
     expect(query.tree).to eq [{described_class::VACUUM_STMT=>
           {"options"=>1,
            "relation"=>
@@ -160,6 +164,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse("CREATE TEMP TABLE test AS SELECT 1")
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['test']
+    expect(query.modified_tables).to eq ['test']
     expect(query.tree).to eq [{described_class::CREATE_TABLE_AS_STMT=>
           {"query"=>
             {described_class::SELECT_STMT=>
@@ -199,6 +204,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse('CREATE TABLE test (a int4)')
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['test']
+    expect(query.modified_tables).to eq ['test']
     expect(query.tree).to eq [{described_class::CREATE_STMT=>
        {"relation"=>
          {described_class::RANGE_VAR=>
@@ -223,6 +229,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse('CREATE TABLE test (a int4) WITH OIDS')
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['test']
+    expect(query.modified_tables).to eq ['test']
     expect(query.tree).to eq [{described_class::CREATE_STMT=>
        {"relation"=>
          {described_class::RANGE_VAR=>
@@ -248,6 +255,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse('CREATE INDEX testidx ON test USING gist (a)')
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['test']
+    expect(query.administered_tables).to eq ['test']
     expect(query.tree).to eq [{described_class::INDEX_STMT=>
        {"idxname"=>"testidx",
         "relation"=>
@@ -278,6 +286,8 @@ describe PgQuery, '.parse' do
     query = described_class.parse('CREATE VIEW myview AS SELECT * FROM mytab')
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['myview', 'mytab']
+    expect(query.modified_tables).to eq ['myview']
+    expect(query.viewed_tables).to eq ['mytab']
     expect(query.tree).to eq [{described_class::VIEW_STMT=>
      {"view"=>
        {described_class::RANGE_VAR=>
@@ -306,6 +316,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse('REFRESH MATERIALIZED VIEW myview')
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['myview']
+    expect(query.modified_tables).to eq ['myview']
     expect(query.tree).to eq [{described_class::REFRESH_MAT_VIEW_STMT=>
    {"relation"=>
      {described_class::RANGE_VAR=>
@@ -409,6 +420,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse('GRANT INSERT, UPDATE ON mytable TO myuser')
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['mytable']
+    expect(query.administered_tables).to eq ['mytable']
     expect(query.tree).to eq [{described_class::GRANT_STMT=>
        {"is_grant"=>true,
         "targtype"=>0,
@@ -440,6 +452,7 @@ describe PgQuery, '.parse' do
     query = described_class.parse('TRUNCATE bigtable, fattable RESTART IDENTITY')
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['bigtable', 'fattable']
+    expect(query.modified_tables).to eq ['bigtable', 'fattable']
     expect(query.tree).to eq [{described_class::TRUNCATE_STMT=>
       {"relations"=>
          [{described_class::RANGE_VAR=>
@@ -623,6 +636,7 @@ $BODY$
     query = described_class.parse("select u.email, (select count(*) from enrollments e where e.user_id = u.id) as num_enrollments from users u")
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['users', 'enrollments']
+    expect(query.viewed_tables).to eq ['users', 'enrollments']
   end
 
   # https://github.com/lfittl/pg_query/issues/52
@@ -630,18 +644,21 @@ $BODY$
     query = described_class.parse("WITH cte_name AS (SELECT 1) SELECT * FROM table_name, cte_name")
     expect(query.cte_names).to eq ['cte_name']
     expect(query.tables).to eq ['table_name']
+    expect(query.viewed_tables).to eq ['table_name']
   end
 
   it 'correctly finds nested tables in from clause' do
     query = described_class.parse("select u.* from (select * from users) u")
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['users']
+    expect(query.viewed_tables).to eq ['users']
   end
 
   it 'correctly finds nested tables in where clause' do
     query = described_class.parse("select users.id from users where 1 = (select count(*) from user_roles)")
     expect(query.warnings).to eq []
     expect(query.tables).to eq ['users', 'user_roles']
+    expect(query.viewed_tables).to eq ['users', 'user_roles']
   end
 
   it 'traverse boolean expressions in where clause' do


### PR DESCRIPTION
For our application ([Polizei](https://github.com/605data/redshift_polizei), a Sinatra app for monitoring a Redshift cluster), we need to distinguish between different types of table access. For example, we'd like to know what tables were simply viewed (i.e. through a SELECT), modified (with e.g. INSERT, UPDATE, CREATE, etc. statements), or had administrative actions performed on them (e.g. VACUUM, GRANT, etc.).

I modified the parse spec to check that queries are properly classified, but additional tests might be nice (e.g. there are relatively few modifying queries in the spec). If you find this useful, feel free to merge or request additional changes. If not, no sweat.