### PR TITLE
Tables in subselects in joins

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -201,6 +201,10 @@ class PgQuery
         table = [rangevar['schemaname'], rangevar['relname']].compact.join('.')
         @tables << { table: table, type: next_item[:type] }
         @aliases[rangevar['alias'][ALIAS]['aliasname']] = table if rangevar['alias']
+      when RANGE_SUBSELECT
+        from_clause_items << { item: next_item[:item][RANGE_SUBSELECT]['subquery'], type: next_item[:type] }
+      when SELECT_STMT
+        from_clause_items += next_item[:item][SELECT_STMT]['fromClause'].map {|r| { item: r, type: next_item[:type] }}
       end
     end
 

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -204,7 +204,7 @@ class PgQuery
       when RANGE_SUBSELECT
         from_clause_items << { item: next_item[:item][RANGE_SUBSELECT]['subquery'], type: next_item[:type] }
       when SELECT_STMT
-        from_clause_items += next_item[:item][SELECT_STMT]['fromClause'].map {|r| { item: r, type: next_item[:type] }}
+        from_clause_items += next_item[:item][SELECT_STMT]['fromClause'].map { |r| { item: r, type: next_item[:type] } }
       end
     end
 

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -768,6 +768,17 @@ $BODY$
     expect(query.tables).to eq ['users', 'user_roles']
   end
 
+  it 'correctly finds nested tables in a subselect on a join' do
+    query = described_class.parse(<<-SQL)
+      select foo.*
+      from foo
+      join ( select * from bar ) b
+      on b.baz = foo.quux
+    SQL
+    expect(query.warnings).to eq []
+    expect(query.tables).to eq ['foo', 'bar']
+  end
+
   it 'handles DROP TYPE' do
     query = described_class.parse("DROP TYPE IF EXISTS repack.pk_something")
     expect(query.warnings).to eq []


### PR DESCRIPTION
In reference to #67 Fixes the corner case where
```
> query = PgQuery.parse('select foo.*
  from foo
  join ( select * from bar ) b
  on b.baz = foo.quux')
> query.tables
  ['foo']
```
rather than
```
> query.tables
  ['foo', 'bar']
```