### PR TITLE
fix to properly identify CTEs in union select queries

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -87,19 +87,19 @@ class PgQuery
                 from_clause_items << { item: item, type: :select }
               end
             end
-
-            # CTEs
-            with_clause = statement[SELECT_STMT]['withClause']
-            if with_clause
-              with_clause[WITH_CLAUSE]['ctes'].each do |item|
-                next unless item[COMMON_TABLE_EXPR]
-                @cte_names << item[COMMON_TABLE_EXPR]['ctename']
-                statements << item[COMMON_TABLE_EXPR]['ctequery']
-              end
-            end
           when 1
             statements << statement[SELECT_STMT]['larg'] if statement[SELECT_STMT]['larg']
             statements << statement[SELECT_STMT]['rarg'] if statement[SELECT_STMT]['rarg']
+          end
+
+          # CTEs
+          with_clause = statement[SELECT_STMT]['withClause']
+          if with_clause
+            with_clause[WITH_CLAUSE]['ctes'].each do |item|
+              next unless item[COMMON_TABLE_EXPR]
+              @cte_names << item[COMMON_TABLE_EXPR]['ctename']
+              statements << item[COMMON_TABLE_EXPR]['ctequery']
+            end
           end
         # The following statements modify the contents of a table
         when INSERT_STMT, UPDATE_STMT, DELETE_STMT

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -787,6 +787,24 @@ $BODY$
     expect(query.tables).to eq ['foo', 'bar']
   end
 
+  it 'does not list CTEs as tables after a union select' do
+    query = described_class.parse(<<-SQL)
+      with cte_a as (
+        select * from table_a
+      ), cte_b as (
+        select * from table_b
+      )
+
+      select id from table_c
+      left join cte_b on
+        table_c.id = cte_b.c_id
+      union
+      select * from cte_a
+    SQL
+    expect(query.tables).to match_array(['table_a', 'table_b', 'table_c'])
+    expect(query.cte_names).to match_array(['cte_a', 'cte_b'])
+  end
+
   it 'handles DROP TYPE' do
     query = described_class.parse("DROP TYPE IF EXISTS repack.pk_something")
     expect(query.warnings).to eq []


### PR DESCRIPTION
This addresses #70 
I have limited understanding of the parsetree, but the existing implementation only searches for CTEs when the statement `['op']` is `0` (couldn't find any documentation about this, would be interested to learn more.) The apparent effective fix was to have it run inside of the `SELECT_STMT` block regardless of statement `op`.

```
query = PgQuery.parse(<<-SQL)
WITH foo (SELECT * FROM bar)
SELECT * FROM baz
UNION
SELECT * FROM foo
```
Formerly:
```
query.tables
> ['foo', 'baz']
query.cte_names
> []
```
post fix:
```
query.tables
> ['bar', 'baz']
query.cte_names
> ['foo']
```

