### PR TITLE
Fix Ruby warnings on uninitialized instance variables

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -27,6 +27,9 @@ class PgQuery
     @query = query
     @tree = tree
     @warnings = warnings
+    @tables = nil
+    @aliases = nil
+    @cte_names = nil
   end
 
   def tables


### PR DESCRIPTION
Hi, thanks for the project. We noticed that Ruby prints a bunch of warning messages while running test for our project depending on pg_query.

```sh
RUBYOPT=-w bundle exec rake test 2>&1 > /dev/null | grep 'not initialized' | wc -l
```

The patch fixes it by explicitly setting instance variables during construction. I know it's not really an issue, so feel free to close it if you want to keep it as it is. Thanks.