### PR TITLE
Drop JSON dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,12 @@ PATH
   remote: .
   specs:
     pg_query (1.0.0)
-      json (>= 1.8, < 3)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.3.0)
     diff-lcs (1.3)
-    json (2.1.0)
     parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -55,4 +53,4 @@ DEPENDENCIES
   rubocop-rspec (= 1.15.1)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/pg_query.gemspec
+++ b/pg_query.gemspec
@@ -25,6 +25,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '0.49.1'
   s.add_development_dependency 'rubocop-rspec', '1.15.1'
-
-  s.add_runtime_dependency 'json', '>= 1.8', '< 3'
 end


### PR DESCRIPTION
All major Ruby implementations such as MRI, JRuby, and Rubinius ship with JSON. Many gems including [Rails already stepped away](https://github.com/rails/rails/pull/23453) from it, and it is no longer necessary to depend on it. 