### PR TITLE
Deparse SELECT DISTINCT clause

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -681,6 +681,7 @@ class PgQuery
 
       if node[TARGET_LIST_FIELD]
         output << 'SELECT'
+        output << 'DISTINCT' if node['distinctClause']
         output << node[TARGET_LIST_FIELD].map do |item|
           deparse_item(item, :select)
         end.join(', ')

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -14,6 +14,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'with DISTINCT' do
+        let(:query) { 'SELECT DISTINCT "a", "b", * FROM "c" WHERE "d" = "e"' }
+
+        it { is_expected.to eq query }
+      end
+
       context 'complex SELECT statement' do
         let(:query) { 'SELECT "memory_total_bytes", "memory_swap_total_bytes" - "memory_swap_free_bytes" AS swap, date_part(?, "s"."collected_at") AS collected_at FROM "snapshots" s JOIN "system_snapshots" ON "snapshot_id" = "s"."id" WHERE "s"."database_id" = ? AND "s"."collected_at" >= ? AND "s"."collected_at" <= ? ORDER BY "collected_at" ASC' }
 


### PR DESCRIPTION
Hello,

I noticed that a query like `SELECT DISTINCT * FROM a` didn't retain the `DISTINCT` upon deparsing.  So I added it.  Hope the added spec is adequate.

Oh and thanks for this gem and the underlying C lib, that's exactly what I needed!

Cheers.