### PR TITLE
Support deparsing "CASE expr WHEN ... END" clause

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -528,6 +528,7 @@ class PgQuery
 
     def deparse_case(node)
       output = ['CASE']
+      output << deparse_item(node['arg']) if node['arg']
       output += node['args'].map { |arg| deparse_item(arg) }
       if node['defresult']
         output << 'ELSE'

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -148,6 +148,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'CASE condition WHEN clause' do
+        let(:query) { 'SELECT CASE 1 > 0 WHEN true THEN \'ok\' ELSE NULL END' }
+
+        it { is_expected.to eq query }
+      end
+
       context 'CASE WHEN statements with ELSE clause' do
         let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' ELSE \'unknown\' END FROM "accounts" a' }
 


### PR DESCRIPTION
Hi,

I found another syntax case where deparse forgot to output something.  It's the expression in `CASE expr WHEN ... END`, the docs call it "simple CASE":

[§9.17.1 CASE](https://www.postgresql.org/docs/10/static/functions-conditional.html#FUNCTIONS-CASE)

> There is a “simple” form of CASE expression that is a variant of the general form above:
>
> ```
> CASE expression
>     WHEN value THEN result
>     [WHEN ...]
>     [ELSE result]
> END
> ```
>
>The first expression is computed, then compared to each of the value expressions in the WHEN clauses until one is found that is equal to it. If no match is found, the result of the ELSE clause (or a null value) is returned. This is similar to the switch statement in C.

I was rather confused why the AST I built didn't have the expression lul..