### PR TITLE
Deparse GRANT statements

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -45,6 +45,8 @@ class PgQuery
         else
           raise format("Can't deparse: %s: %s", type, node.inspect)
         end
+      when ACCESS_PRIV
+        deparse_access_priv(node)
       when ALIAS
         deparse_alias(node)
       when ALTER_TABLE_STMT
@@ -108,6 +110,10 @@ class PgQuery
         deparse_funccall(node)
       when FUNCTION_PARAMETER
         deparse_functionparameter(node)
+      when GRANT_ROLE_STMT
+        deparse_grant_role(node)
+      when GRANT_STMT
+        deparse_grant(node)
       when INSERT_STMT
         deparse_insert_into(node)
       when JOIN_EXPR
@@ -118,6 +124,8 @@ class PgQuery
         deparse_lockingclause(node)
       when NULL_TEST
         deparse_nulltest(node)
+      when OBJECT_WITH_ARGS
+        deparse_object_with_args(node)
       when PARAM_REF
         deparse_paramref(node)
       when RANGE_FUNCTION
@@ -132,6 +140,8 @@ class PgQuery
         deparse_renamestmt(node)
       when RES_TARGET
         deparse_restarget(node, context)
+      when ROLE_SPEC
+        deparse_role_spec(node)
       when ROW_EXPR
         deparse_row(node)
       when SELECT_STMT
@@ -284,6 +294,16 @@ class PgQuery
       output.compact.join(' ')
     end
 
+    def deparse_object_with_args(node)
+      output = []
+      output += node['objname'].map(&method(:deparse_item))
+      unless node['args_unspecified']
+        args = node.fetch('objargs', []).map(&method(:deparse_item)).join(', ')
+        output << "(#{args})"
+      end
+      output.join('')
+    end
+
     def deparse_paramref(node)
       if node['number'].nil?
         '?'
@@ -342,6 +362,71 @@ class PgQuery
 
     def deparse_functionparameter(node)
       deparse_item(node['argType'])
+    end
+
+    def deparse_grant_role(node)
+      output = ['GRANT']
+      output << node['granted_roles'].map(&method(:deparse_item)).join(', ')
+      output << 'TO'
+      output << node['grantee_roles'].map(&method(:deparse_item)).join(', ')
+      output << 'WITH ADMIN OPTION' if node['admin_opt']
+      output.join(' ')
+    end
+
+    def deparse_grant(node)
+      objtype, allow_all = deparse_grant_objtype(node)
+      output = ['GRANT']
+      output << if node.key?('privileges')
+                  node['privileges'].map(&method(:deparse_item)).join(', ')
+                else
+                  'ALL'
+                end
+      output << 'ON'
+      objects = node['objects']
+      objects = objects[0] if %w[DOMAIN TYPE].include?(objtype) # FIXME: error in parser?
+      objects = objects.map do |object|
+        deparsed = deparse_item(object)
+        if object.key?(RANGE_VAR) || object.key?(OBJECT_WITH_ARGS) || !allow_all
+          objtype == 'TABLE' ? deparsed : "#{objtype} #{deparsed}"
+        else
+          "ALL #{objtype}S IN SCHEMA #{deparsed}"
+        end
+      end
+      output << objects.join(', ')
+      output << 'TO'
+      output << node['grantees'].map(&method(:deparse_item)).join(', ')
+      output << 'WITH GRANT OPTION' if node['grant_option']
+      output.join(' ')
+    end
+
+    def deparse_grant_objtype(node)
+      {
+        1 => ['TABLE', true],
+        2 => ['SEQUENCE', true],
+        3 => ['DATABASE', false],
+        4 => ['DOMAIN', false],
+        5 => ['FOREIGN DATA WRAPPER', false],
+        6 => ['FOREIGN SERVER', false],
+        7 => ['FUNCTION', true],
+        8 => ['LANGUAGE', false],
+        9 => ['LARGE OBJECT', false],
+        10 => ['SCHEMA', false],
+        11 => ['TABLESPACE', false],
+        12 => ['TYPE', false]
+      }.fetch(node['objtype'])
+    end
+
+    def deparse_access_priv(node)
+      output = [node['priv_name']]
+      output << "(#{node['cols'].map(&method(:deparse_item)).join(', ')})" if node.key?('cols')
+      output.join(' ')
+    end
+
+    def deparse_role_spec(node)
+      return 'CURRENT_USER' if node['roletype'] == 1
+      return 'SESSION_USER' if node['roletype'] == 2
+      return 'PUBLIC' if node['roletype'] == 3
+      format('"%s"', node['rolename'].gsub('"', '""'))
     end
 
     def deparse_aexpr_in(node)

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -55,6 +55,7 @@ class PgQuery
   LOCKING_CLAUSE = 'LockingClause'.freeze
   NULL = 'Null'.freeze
   NULL_TEST = 'NullTest'.freeze
+  OBJECT_WITH_ARGS = 'ObjectWithArgs'.freeze
   OID_LIST = 'OidList'.freeze
   PARAM_REF = 'ParamRef'.freeze
   PREPARE_STMT = 'PrepareStmt'.freeze

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -1131,6 +1131,188 @@ describe PgQuery::Deparse do
         it { is_expected.to eq oneline_query }
       end
     end
+
+    context 'GRANT' do
+      context 'basic select statement' do
+        let(:query) { 'GRANT select ON "table" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'multiple privileges' do
+        let(:query) { 'GRANT select, update, insert ON "table" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'all tables' do
+        let(:query) { 'GRANT select ON ALL TABLES IN SCHEMA "schema" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'multiple users' do
+        let(:query) { 'GRANT select ON "table" TO "user1", "user2"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'user public' do
+        let(:query) { 'GRANT select ON "table" TO PUBLIC' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'user current user' do
+        let(:query) { 'GRANT select ON "table" TO CURRENT_USER' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'user session user' do
+        let(:query) { 'GRANT select ON "table" TO SESSION_USER' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'all privileges' do
+        let(:query) { 'GRANT ALL ON "table" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with grant option' do
+        let(:query) { 'GRANT select ON "table" TO "user" WITH GRANT OPTION' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with column name' do
+        let(:query) { 'GRANT select ("column") ON "table" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with column names' do
+        let(:query) { 'GRANT select ("column1", "column2") ON "table" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'sequence' do
+        let(:query) { 'GRANT usage ON SEQUENCE "sequence" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'all sequences' do
+        let(:query) { 'GRANT usage ON ALL SEQUENCES IN SCHEMA "schema" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'database' do
+        let(:query) { 'GRANT create ON DATABASE "database" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'domain' do
+        let(:query) { 'GRANT usage ON DOMAIN "domain" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'foreign data wrapper' do
+        let(:query) { 'GRANT usage ON FOREIGN DATA WRAPPER "fdw" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'foreign server' do
+        let(:query) { 'GRANT usage ON FOREIGN SERVER "server" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'function with unspecified args' do
+        let(:query) { 'GRANT execute ON FUNCTION "function" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'function without args' do
+        let(:query) { 'GRANT execute ON FUNCTION "function"() TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'function without 1 arg' do
+        let(:query) { 'GRANT execute ON FUNCTION "function"(string) TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'function without multiple args' do
+        let(:query) { 'GRANT execute ON FUNCTION "function"(string, string, boolean) TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'all functions' do
+        let(:query) { 'GRANT execute ON ALL FUNCTIONS IN SCHEMA "schema" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'language' do
+        let(:query) { 'GRANT usage ON LANGUAGE "plpgsql" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'large object' do
+        let(:query) { 'GRANT select ON LARGE OBJECT 1234 TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'schema' do
+        let(:query) { 'GRANT create ON SCHEMA "schema" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'tablespace' do
+        let(:query) { 'GRANT create ON TABLESPACE "tablespace" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'type' do
+        let(:query) { 'GRANT usage ON TYPE "type" TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'role' do
+        let(:query) { 'GRANT role TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'multiple roles' do
+        let(:query) { 'GRANT role1, role2 TO "user"' }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with admin option' do
+        let(:query) { 'GRANT role TO "user" WITH ADMIN OPTION' }
+
+        it { is_expected.to eq oneline_query }
+      end
+    end
   end
 
   describe '#deparse' do


### PR DESCRIPTION
This fixes #114 

This is a work in progress, Rubocop will find an offense for complexity. But before I fix that, a quick question. In case of parsing a grant on DOMAIN or TYPE, I get an extra array around the objects, which required this hack:

```ruby
objects = node['objects']
objects = objects[0] if %w[DOMAIN TYPE].include?(objtype)
objects = objects.map do |object|
```

(Most likely `node['objects'].flat_map` would work as well) But it feels like there is a bug somewhere in the parse results. Any idea if this could be something in this gem, or maybe something in Postgresql?