### PR TITLE
ILIKE,COLLATE and DISCARD deparse

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1107,7 +1107,7 @@ class PgQuery
 
     def deparse_discard(node)
       output = ['DISCARD']
-      output << 'ALL' if node['target'] == 0
+      output << 'ALL' if (node['target']).zero?
       output << 'PLANS' if node['target'] == 1
       output << 'SEQUENCES' if node['target'] == 2
       output << 'TEMP' if node['target'] == 3

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -524,7 +524,7 @@ class PgQuery
       output = []
       output << deparse_item(node['arg'])
       output << 'COLLATE'
-      output <<  deparse_item_list(node['collname'])
+      output << deparse_item_list(node['collname'])
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -80,6 +80,8 @@ class PgQuery
         deparse_case(node)
       when COALESCE_EXPR
         deparse_coalesce(node)
+      when COLLATE_CLAUSE
+        deparse_collate(node)
       when COLUMN_DEF
         deparse_columndef(node)
       when COLUMN_REF
@@ -102,6 +104,8 @@ class PgQuery
         deparse_defelem(node)
       when DELETE_STMT
         deparse_delete_from(node)
+      when DISCARD_STMT
+        deparse_discard(node)
       when DROP_STMT
         deparse_drop(node)
       when EXPLAIN_STMT
@@ -180,8 +184,6 @@ class PgQuery
         node['str']
       when NULL
         'NULL'
-      when COLLATE_CLAUSE
-        deparse_collate(node)
       else
         raise format("Can't deparse: %s: %s", type, node.inspect)
       end
@@ -1100,6 +1102,15 @@ class PgQuery
         end.join(', ')
       end
 
+      output.join(' ')
+    end
+
+    def deparse_discard(node)
+      output = ['DISCARD']
+      output << 'ALL' if node['target'] == 0
+      output << 'PLANS' if node['target'] == 1
+      output << 'SEQUENCES' if node['target'] == 2
+      output << 'TEMP' if node['target'] == 3
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -180,6 +180,8 @@ class PgQuery
         node['str']
       when NULL
         'NULL'
+      when COLLATE_CLAUSE
+        deparse_collate(node)
       else
         raise format("Can't deparse: %s: %s", type, node.inspect)
       end
@@ -515,6 +517,14 @@ class PgQuery
       output << 'DESC' if node['sortby_dir'] == 2
       output << 'NULLS FIRST' if node['sortby_nulls'] == 1
       output << 'NULLS LAST' if node['sortby_nulls'] == 2
+      output.join(' ')
+    end
+
+    def deparse_collate(node)
+      output = []
+      output << deparse_item(node['arg'])
+      output << 'COLLATE'
+      output <<  deparse_item_list(node['collname'])
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -36,6 +36,8 @@ class PgQuery
           deparse_aexpr_any(node)
         when AEXPR_IN
           deparse_aexpr_in(node)
+        when AEXPR_ILIKE
+          deparse_aexpr_ilike(node)
         when CONSTR_TYPE_FOREIGN
           deparse_aexpr_like(node)
         when AEXPR_BETWEEN, AEXPR_NOT_BETWEEN, AEXPR_BETWEEN_SYM, AEXPR_NOT_BETWEEN_SYM
@@ -353,6 +355,12 @@ class PgQuery
     def deparse_aexpr_like(node)
       value = deparse_item(node['rexpr'])
       operator = node['name'].map { |n| deparse_item(n, :operator) } == ['~~'] ? 'LIKE' : 'NOT LIKE'
+      format('%s %s %s', deparse_item(node['lexpr']), operator, value)
+    end
+
+    def deparse_aexpr_ilike(node)
+      value = deparse_item(node['rexpr'])
+      operator = node['name'][0]['String']['str'] == '~~*' ? 'ILIKE' : 'NOT ILIKE'
       format('%s %s %s', deparse_item(node['lexpr']), operator, value)
     end
 

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -20,6 +20,7 @@ class PgQuery
   CHECK_POINT_STMT = 'CheckPointStmt'.freeze
   CLOSE_PORTAL_STMT = 'ClosePortalStmt'.freeze
   COALESCE_EXPR = 'CoalesceExpr'.freeze
+  COLLATE_CLAUSE = 'CollateClause'.freeze
   COLUMN_DEF = 'ColumnDef'.freeze
   COLUMN_REF = 'ColumnRef'.freeze
   COMMON_TABLE_EXPR = 'CommonTableExpr'.freeze
@@ -34,6 +35,7 @@ class PgQuery
   DECLARE_CURSOR_STMT = 'DeclareCursorStmt'.freeze
   DEF_ELEM = 'DefElem'.freeze
   DELETE_STMT = 'DeleteStmt'.freeze
+  DISCARD_STMT = 'DiscardStmt'.freeze
   DO_STMT = 'DoStmt'.freeze
   DROP_STMT = 'DropStmt'.freeze
   EXECUTE_STMT = 'ExecuteStmt'.freeze
@@ -85,7 +87,6 @@ class PgQuery
   VIEW_STMT = 'ViewStmt'.freeze
   WINDOW_DEF = 'WindowDef'.freeze
   WITH_CLAUSE = 'WithClause'.freeze
-  COLLATE_CLAUSE = 'CollateClause'.freeze
 
   # FIELDS
 

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -85,6 +85,7 @@ class PgQuery
   VIEW_STMT = 'ViewStmt'.freeze
   WINDOW_DEF = 'WindowDef'.freeze
   WITH_CLAUSE = 'WithClause'.freeze
+  COLLATE_CLAUSE = 'CollateClause'.freeze
 
   # FIELDS
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -62,6 +62,18 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'ORDER BY with COLLATE' do
+        let(:query) { 'SELECT * FROM "a" ORDER BY "x" COLLATE "tr_TR" DESC NULLS LAST' }
+
+        it { is_expected.to eq query }
+      end
+
+      context 'text with COLLATE' do
+        let(:query) { "SELECT 'foo' COLLATE \"tr_TR\"" }
+
+        it { is_expected.to eq query }
+      end
+
       context 'with specific column alias' do
         let(:query) { "SELECT * FROM (VALUES ('anne', 'smith'), ('bob', 'jones'), ('joe', 'blow')) names(\"first\", \"last\")" }
 
@@ -76,6 +88,18 @@ describe PgQuery::Deparse do
 
       context 'with NOT LIKE filter' do
         let(:query) { "SELECT * FROM \"users\" WHERE \"name\" NOT LIKE 'postgresql:%';" }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with ILIKE filter' do
+        let(:query) { "SELECT * FROM \"users\" WHERE \"name\" ILIKE 'postgresql:%';" }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with NOT ILIKE filter' do
+        let(:query) { "SELECT * FROM \"users\" WHERE \"name\" NOT ILIKE 'postgresql:%';" }
 
         it { is_expected.to eq oneline_query }
       end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -1155,6 +1155,29 @@ describe PgQuery::Deparse do
         it { is_expected.to eq oneline_query }
       end
     end
+
+    context 'DISCARD' do
+      context 'all' do
+        let(:query) { 'DISCARD ALL' }
+
+        it { is_expected.to eq oneline_query }
+      end
+      context 'plans' do
+        let(:query) { 'DISCARD PLANS' }
+
+        it { is_expected.to eq oneline_query }
+      end
+      context 'sequences' do
+        let(:query) { 'DISCARD SEQUENCES' }
+
+        it { is_expected.to eq oneline_query }
+      end
+      context 'temp' do
+        let(:query) { 'DISCARD TEMP' }
+
+        it { is_expected.to eq oneline_query }
+      end
+    end
   end
 
   describe '#deparse' do


### PR DESCRIPTION
Deparse exception for ILIKE  statements and COLLATE. I fix it. Now we can use ILIKE  statements and COLLATE.