### PR TITLE
Support OpenBSD tar by using explicit tar -xzf

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -19,7 +19,7 @@ unless File.exist?("#{workdir}/libpg_query.tar.gz")
 end
 
 unless Dir.exist?(libdir)
-  system("tar -xf #{workdir}/libpg_query.tar.gz") || raise('ERROR')
+  system("tar -xzf #{workdir}/libpg_query.tar.gz") || raise('ERROR')
 end
 
 unless Dir.exist?(libfile)


### PR DESCRIPTION
OpenBSD tar won't try to extract the compressed archive if no format type (z/j/...) is specified and trying to install `pg_query` gem on OpenBSD system will result in the following error:

```
tar: input compressed with gzip; use the -z option to decompress it
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/home/sirn/.asdf/installs/ruby/2.6.2/bin/$(RUBY_BASE_NAME)
extconf.rb:22:in `<main>': ERROR (RuntimeError)

extconf failed, exit code 1
```

This PR fixes the error by adding `z` to the tar command in extconf.