### PR TITLE
ALL operator, UNION, EXCEPT, Renamed Columns and Empty Array  problem, CREATE SCHEMA, CREATE CAST for deparsing

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -803,6 +803,13 @@ class PgQuery
         output.join(' ')
       end
 
+      if node['op'] == 3
+        output << deparse_item(node['larg'])
+        output << 'EXCEPT'
+        output << deparse_item(node['rarg'])
+        output.join(' ')
+      end
+
       if node[TARGET_LIST_FIELD]
         output << 'SELECT'
         if node['distinctClause']

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1107,7 +1107,7 @@ class PgQuery
 
     def deparse_discard(node)
       output = ['DISCARD']
-      output << 'ALL' if node['target'] == 0
+      output << 'ALL' if (node['target']).zero?
       output << 'PLANS' if node['target'] == 1
       output << 'SEQUENCES' if node['target'] == 2
       output << 'TEMP' if node['target'] == 3

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -524,7 +524,7 @@ class PgQuery
       output = []
       output << deparse_item(node['arg'])
       output << 'COLLATE'
-      output <<  deparse_item_list(node['collname'])
+      output << deparse_item_list(node['collname'])
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -769,7 +769,7 @@ class PgQuery
       if node['subLinkType'] == SUBLINK_TYPE_ANY
         format('%s IN (%s)', deparse_item(node['testexpr']), deparse_item(node['subselect']))
       elsif node['subLinkType'] == SUBLINK_TYPE_ALL
-        format('%s %s ALL (%s)', deparse_item(node['testexpr']),deparse_item(node['operName'][0], :operator), deparse_item(node['subselect']))
+        format('%s %s ALL (%s)', deparse_item(node['testexpr']), deparse_item(node['operName'][0], :operator), deparse_item(node['subselect']))
       elsif node['subLinkType'] == SUBLINK_TYPE_EXISTS
         format('EXISTS(%s)', deparse_item(node['subselect']))
       else

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -261,7 +261,7 @@ class PgQuery
       if node['colnames']
         name + '(' + deparse_item_list(node['colnames']).join(', ') + ')'
       else
-        format('"%s"',name)  if !name.nil?
+        format('"%s"', name) unless name.nil?
       end
     end
 
@@ -302,7 +302,7 @@ class PgQuery
 
     def deparse_restarget(node, context)
       if context == :select
-        [deparse_item(node['val']), (format('"%s"',node['name'])  if !node['name'].nil?) ].compact.join(' AS ')
+        [deparse_item(node['val']), (format('"%s"', node['name']) unless node['name'].nil?)].compact.join(' AS ')
       elsif context == :update
         [node['name'], deparse_item(node['val'])].compact.join(' = ')
       elsif node['val'].nil?

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -32,6 +32,8 @@ class PgQuery
         case node['kind']
         when AEXPR_OP
           deparse_aexpr(node, context)
+        when AEXPR_OP_ALL
+          deparse_aexpr_all(node)
         when AEXPR_OP_ANY
           deparse_aexpr_any(node)
         when AEXPR_IN
@@ -434,6 +436,13 @@ class PgQuery
       output.join(' ' + deparse_item(node['name'][0], :operator) + ' ')
     end
 
+    def deparse_aexpr_all(node)
+      output = []
+      output << deparse_item(node['lexpr'])
+      output << format('ALL(%s)', deparse_item(node['rexpr']))
+      output.join(' ' + deparse_item(node['name'][0], :operator) + ' ')
+    end
+
     def deparse_aexpr_between(node)
       between = case node['kind']
                 when AEXPR_BETWEEN
@@ -759,6 +768,8 @@ class PgQuery
     def deparse_sublink(node)
       if node['subLinkType'] == SUBLINK_TYPE_ANY
         format('%s IN (%s)', deparse_item(node['testexpr']), deparse_item(node['subselect']))
+      elsif node['subLinkType'] == SUBLINK_TYPE_ALL
+        format('%s %s ALL (%s)', deparse_item(node['testexpr']),deparse_item(node['operName'][0], :operator), deparse_item(node['subselect']))
       elsif node['subLinkType'] == SUBLINK_TYPE_EXISTS
         format('EXISTS(%s)', deparse_item(node['subselect']))
       else

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -80,6 +80,8 @@ class PgQuery
         deparse_case(node)
       when COALESCE_EXPR
         deparse_coalesce(node)
+      when COLLATE_CLAUSE
+        deparse_collate(node)
       when COLUMN_DEF
         deparse_columndef(node)
       when COLUMN_REF
@@ -102,6 +104,8 @@ class PgQuery
         deparse_defelem(node)
       when DELETE_STMT
         deparse_delete_from(node)
+      when DISCARD_STMT
+        deparse_discard(node)
       when DROP_STMT
         deparse_drop(node)
       when EXPLAIN_STMT
@@ -180,8 +184,6 @@ class PgQuery
         node['str']
       when NULL
         'NULL'
-      when COLLATE_CLAUSE
-        deparse_collate(node)
       else
         raise format("Can't deparse: %s: %s", type, node.inspect)
       end
@@ -1100,6 +1102,15 @@ class PgQuery
         end.join(', ')
       end
 
+      output.join(' ')
+    end
+
+    def deparse_discard(node)
+      output = ['DISCARD']
+      output << 'ALL' if node['target'] == 0
+      output << 'PLANS' if node['target'] == 1
+      output << 'SEQUENCES' if node['target'] == 2
+      output << 'TEMP' if node['target'] == 3
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -793,15 +793,15 @@ class PgQuery
     def deparse_select(node) # rubocop:disable Metrics/CyclomaticComplexity
       output = []
 
+      output << deparse_item(node['withClause']) if node['withClause']
+
       if node['op'] == 1
         output << deparse_item(node['larg'])
         output << 'UNION'
         output << 'ALL' if node['all']
         output << deparse_item(node['rarg'])
-        return output.join(' ')
+        output.join(' ')
       end
-
-      output << deparse_item(node['withClause']) if node['withClause']
 
       if node[TARGET_LIST_FIELD]
         output << 'SELECT'

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -180,6 +180,8 @@ class PgQuery
         node['str']
       when NULL
         'NULL'
+      when COLLATE_CLAUSE
+        deparse_collate(node)
       else
         raise format("Can't deparse: %s: %s", type, node.inspect)
       end
@@ -515,6 +517,14 @@ class PgQuery
       output << 'DESC' if node['sortby_dir'] == 2
       output << 'NULLS FIRST' if node['sortby_nulls'] == 1
       output << 'NULLS LAST' if node['sortby_nulls'] == 2
+      output.join(' ')
+    end
+
+    def deparse_collate(node)
+      output = []
+      output << deparse_item(node['arg'])
+      output << 'COLLATE'
+      output <<  deparse_item_list(node['collname'])
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -231,9 +231,13 @@ class PgQuery
     end
 
     def deparse_a_arrayexp(node)
-      'ARRAY[' + node['elements'].map do |element|
-        deparse_item(element)
-      end.join(', ') + ']'
+      output = 'ARRAY['
+      unless node['elements'].nil?
+        output << node['elements'].map do |element|
+          deparse_item(element)
+        end.join(', ')
+      end
+      output << ']'
     end
 
     def deparse_a_const(node)

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -36,6 +36,8 @@ class PgQuery
           deparse_aexpr_any(node)
         when AEXPR_IN
           deparse_aexpr_in(node)
+        when AEXPR_ILIKE
+          deparse_aexpr_ilike(node)
         when CONSTR_TYPE_FOREIGN
           deparse_aexpr_like(node)
         when AEXPR_BETWEEN, AEXPR_NOT_BETWEEN, AEXPR_BETWEEN_SYM, AEXPR_NOT_BETWEEN_SYM
@@ -353,6 +355,12 @@ class PgQuery
     def deparse_aexpr_like(node)
       value = deparse_item(node['rexpr'])
       operator = node['name'].map { |n| deparse_item(n, :operator) } == ['~~'] ? 'LIKE' : 'NOT LIKE'
+      format('%s %s %s', deparse_item(node['lexpr']), operator, value)
+    end
+
+    def deparse_aexpr_ilike(node)
+      value = deparse_item(node['rexpr'])
+      operator = node['name'][0]['String']['str'] == '~~*' ? 'ILIKE' : 'NOT ILIKE'
       format('%s %s %s', deparse_item(node['lexpr']), operator, value)
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -261,7 +261,7 @@ class PgQuery
       if node['colnames']
         name + '(' + deparse_item_list(node['colnames']).join(', ') + ')'
       else
-        name
+        format('"%s"',name)  if !name.nil?
       end
     end
 
@@ -302,7 +302,7 @@ class PgQuery
 
     def deparse_restarget(node, context)
       if context == :select
-        [deparse_item(node['val']), node['name']].compact.join(' AS ')
+        [deparse_item(node['val']), (format('"%s"',node['name'])  if !node['name'].nil?) ].compact.join(' AS ')
       elsif context == :update
         [node['name'], deparse_item(node['val'])].compact.join(' = ')
       elsif node['val'].nil?

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -26,6 +26,7 @@ class PgQuery
   COMMON_TABLE_EXPR = 'CommonTableExpr'.freeze
   CONSTRAINT = 'Constraint'.freeze
   COPY_STMT = 'CopyStmt'.freeze
+  CREATE_CAST_STMT = 'CreateCastStmt'.freeze
   CREATE_FUNCTION_STMT = 'CreateFunctionStmt'.freeze
   CREATE_SCHEMA_STMT = 'CreateSchemaStmt'.freeze
   CREATE_STMT = 'CreateStmt'.freeze

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -20,6 +20,7 @@ class PgQuery
   CHECK_POINT_STMT = 'CheckPointStmt'.freeze
   CLOSE_PORTAL_STMT = 'ClosePortalStmt'.freeze
   COALESCE_EXPR = 'CoalesceExpr'.freeze
+  COLLATE_CLAUSE = 'CollateClause'.freeze
   COLUMN_DEF = 'ColumnDef'.freeze
   COLUMN_REF = 'ColumnRef'.freeze
   COMMON_TABLE_EXPR = 'CommonTableExpr'.freeze
@@ -34,6 +35,7 @@ class PgQuery
   DECLARE_CURSOR_STMT = 'DeclareCursorStmt'.freeze
   DEF_ELEM = 'DefElem'.freeze
   DELETE_STMT = 'DeleteStmt'.freeze
+  DISCARD_STMT = 'DiscardStmt'.freeze
   DO_STMT = 'DoStmt'.freeze
   DROP_STMT = 'DropStmt'.freeze
   EXECUTE_STMT = 'ExecuteStmt'.freeze
@@ -85,7 +87,6 @@ class PgQuery
   VIEW_STMT = 'ViewStmt'.freeze
   WINDOW_DEF = 'WindowDef'.freeze
   WITH_CLAUSE = 'WithClause'.freeze
-  COLLATE_CLAUSE = 'CollateClause'.freeze
 
   # FIELDS
 

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -85,6 +85,7 @@ class PgQuery
   VIEW_STMT = 'ViewStmt'.freeze
   WINDOW_DEF = 'WindowDef'.freeze
   WITH_CLAUSE = 'WithClause'.freeze
+  COLLATE_CLAUSE = 'CollateClause'.freeze
 
   # FIELDS
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -75,7 +75,7 @@ describe PgQuery::Deparse do
       end
 
       context 'UNION or UNION ALL' do
-        let(:query) { "WITH kodsis AS (SELECT * FROM application), kodsis2 AS (SELECT * FROM application) SELECT * FROM kodsis UNION SELECT * FROM kodsis ORDER BY id DESC" }
+        let(:query) { "WITH kodsis AS (SELECT * FROM \"application\"), kodsis2 AS (SELECT * FROM \"application\") SELECT * FROM \"kodsis\" UNION SELECT * FROM \"kodsis\" ORDER BY \"id\" DESC" }
 
         it { is_expected.to eq query }
       end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -709,6 +709,36 @@ describe PgQuery::Deparse do
       end
     end
 
+    context 'CREATE CAST' do
+      context 'with function' do
+        let(:query) do
+          """
+          CREATE CAST (bigint AS int4) WITH FUNCTION \"int4\"(bigint) AS ASSIGNMENT
+          """.strip
+        end
+
+        it { is_expected.to eq query }
+      end
+      context 'without function' do
+        let(:query) do
+          """
+          CREATE CAST (bigint AS int4) WITHOUT FUNCTION AS IMPLICIT
+          """.strip
+        end
+
+        it { is_expected.to eq query }
+      end
+      context 'with inout' do
+        let(:query) do
+          """
+          CREATE CAST (bigint AS int4) WITH INOUT AS ASSIGNMENT
+          """.strip
+        end
+
+        it { is_expected.to eq query }
+      end
+    end
+
     context 'CREATE FUNCTION' do
       # Taken from http://www.postgresql.org/docs/8.3/static/queries-table-expressions.html
       context 'with inline function definition' do

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -62,6 +62,18 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'ORDER BY with COLLATE' do
+        let(:query) { 'SELECT * FROM "a" ORDER BY "x" COLLATE "tr_TR" DESC NULLS LAST' }
+
+        it { is_expected.to eq query }
+      end
+
+      context 'text with COLLATE' do
+        let(:query) { "SELECT 'foo' COLLATE \"tr_TR\"" }
+
+        it { is_expected.to eq query }
+      end
+
       context 'with specific column alias' do
         let(:query) { "SELECT * FROM (VALUES ('anne', 'smith'), ('bob', 'jones'), ('joe', 'blow')) names(\"first\", \"last\")" }
 
@@ -76,6 +88,18 @@ describe PgQuery::Deparse do
 
       context 'with NOT LIKE filter' do
         let(:query) { "SELECT * FROM \"users\" WHERE \"name\" NOT LIKE 'postgresql:%';" }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with ILIKE filter' do
+        let(:query) { "SELECT * FROM \"users\" WHERE \"name\" ILIKE 'postgresql:%';" }
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'with NOT ILIKE filter' do
+        let(:query) { "SELECT * FROM \"users\" WHERE \"name\" NOT ILIKE 'postgresql:%';" }
 
         it { is_expected.to eq oneline_query }
       end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -74,6 +74,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'UNION or UNION ALL' do
+        let(:query) { "WITH kodsis AS (SELECT * FROM application), kodsis2 AS (SELECT * FROM application) SELECT * FROM kodsis UNION SELECT * FROM kodsis ORDER BY id DESC" }
+
+        it { is_expected.to eq query }
+      end
+
       context 'with specific column alias' do
         let(:query) { "SELECT * FROM (VALUES ('anne', 'smith'), ('bob', 'jones'), ('joe', 'blow')) names(\"first\", \"last\")" }
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -1155,6 +1155,29 @@ describe PgQuery::Deparse do
         it { is_expected.to eq oneline_query }
       end
     end
+
+    context 'DISCARD' do
+      context 'all' do
+        let(:query) { 'DISCARD ALL' }
+
+        it { is_expected.to eq oneline_query }
+      end
+      context 'plans' do
+        let(:query) { 'DISCARD PLANS' }
+
+        it { is_expected.to eq oneline_query }
+      end
+      context 'sequences' do
+        let(:query) { 'DISCARD SEQUENCES' }
+
+        it { is_expected.to eq oneline_query }
+      end
+      context 'temp' do
+        let(:query) { 'DISCARD TEMP' }
+
+        it { is_expected.to eq oneline_query }
+      end
+    end
   end
 
   describe '#deparse' do

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -9,13 +9,13 @@ describe PgQuery::Deparse do
 
     context 'SELECT' do
       context 'basic statement' do
-        let(:query) { 'SELECT "a" AS b FROM "x" WHERE "y" = 5 AND "z" = "y"' }
+        let(:query) { 'SELECT "a" AS "b" FROM "x" WHERE "y" = 5 AND "z" = "y"' }
 
         it { is_expected.to eq query }
       end
 
       context 'basic statement with schema' do
-        let(:query) { 'SELECT "a" AS b FROM "public"."x" WHERE "y" = 5 AND "z" = "y"' }
+        let(:query) { 'SELECT "a" AS "b" FROM "public"."x" WHERE "y" = 5 AND "z" = "y"' }
 
         it { is_expected.to eq query }
       end
@@ -45,7 +45,7 @@ describe PgQuery::Deparse do
       end
 
       context 'complex SELECT statement' do
-        let(:query) { 'SELECT "memory_total_bytes", "memory_swap_total_bytes" - "memory_swap_free_bytes" AS swap, date_part(?, "s"."collected_at") AS collected_at FROM "snapshots" s JOIN "system_snapshots" ON "snapshot_id" = "s"."id" WHERE "s"."database_id" = ? AND "s"."collected_at" >= ? AND "s"."collected_at" <= ? ORDER BY "collected_at" ASC' }
+        let(:query) { 'SELECT "memory_total_bytes", "memory_swap_total_bytes" - "memory_swap_free_bytes" AS "swap", date_part(?, "s"."collected_at") AS "collected_at" FROM "snapshots" "s" JOIN "system_snapshots" ON "snapshot_id" = "s"."id" WHERE "s"."database_id" = ? AND "s"."collected_at" >= ? AND "s"."collected_at" <= ? ORDER BY "collected_at" ASC' }
 
         it { is_expected.to eq query }
       end
@@ -75,7 +75,7 @@ describe PgQuery::Deparse do
       end
 
       context 'UNION or UNION ALL' do
-        let(:query) { "WITH kodsis AS (SELECT * FROM \"application\"), kodsis2 AS (SELECT * FROM \"application\") SELECT * FROM \"kodsis\" UNION SELECT * FROM \"kodsis\" ORDER BY \"id\" DESC" }
+        let(:query) { 'WITH kodsis AS (SELECT * FROM "application"), kodsis2 AS (SELECT * FROM "application") SELECT * FROM "kodsis" UNION SELECT * FROM "kodsis" ORDER BY "id" DESC' }
 
         it { is_expected.to eq query }
       end
@@ -117,7 +117,7 @@ describe PgQuery::Deparse do
       end
 
       context 'simple WITH statement' do
-        let(:query) { 'WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM "t"' }
+        let(:query) { 'WITH t AS (SELECT random() AS "x" FROM generate_series(1, 3)) SELECT * FROM "t"' }
 
         it { is_expected.to eq query }
       end
@@ -130,12 +130,12 @@ describe PgQuery::Deparse do
               SELECT "g"."id", "g"."link", "g"."data", 1,
                 ARRAY[ROW("g"."f1", "g"."f2")],
                 false
-              FROM "graph" g
+              FROM "graph" "g"
             UNION ALL
               SELECT "g"."id", "g"."link", "g"."data", "sg"."depth" + 1,
                 "path" || ROW("g"."f1", "g"."f2"),
                 ROW("g"."f1", "g"."f2") = ANY("path")
-              FROM "graph" g, "search_graph" sg
+              FROM "graph" "g", "search_graph" "sg"
               WHERE "g"."id" = "sg"."link" AND NOT "cycle"
           )
           SELECT "id", "data", "link" FROM "search_graph";
@@ -152,7 +152,7 @@ describe PgQuery::Deparse do
       end
 
       context 'LATERAL' do
-        let(:query) { 'SELECT "m"."name" AS mname, "pname" FROM "manufacturers" m, LATERAL get_product_names("m"."id") pname' }
+        let(:query) { 'SELECT "m"."name" AS "mname", "pname" FROM "manufacturers" "m", LATERAL get_product_names("m"."id") "pname"' }
 
         it { is_expected.to eq query }
       end
@@ -160,8 +160,8 @@ describe PgQuery::Deparse do
       context 'LATERAL JOIN' do
         let(:query) do
           %(
-          SELECT "m"."name" AS mname, "pname"
-            FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true
+          SELECT "m"."name" AS "mname", "pname"
+            FROM "manufacturers" "m" LEFT JOIN LATERAL get_product_names("m"."id") "pname" ON true
           )
         end
 
@@ -239,7 +239,7 @@ describe PgQuery::Deparse do
       end
 
       context 'basic CASE WHEN statements' do
-        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' END FROM "accounts" a' }
+        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' END FROM "accounts" "a"' }
 
         it { is_expected.to eq query }
       end
@@ -251,7 +251,7 @@ describe PgQuery::Deparse do
       end
 
       context 'CASE WHEN statements with ELSE clause' do
-        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' ELSE \'unknown\' END FROM "accounts" a' }
+        let(:query) { 'SELECT CASE WHEN "a"."status" = 1 THEN \'active\' WHEN "a"."status" = 2 THEN \'inactive\' ELSE \'unknown\' END FROM "accounts" "a"' }
 
         it { is_expected.to eq query }
       end
@@ -275,7 +275,7 @@ describe PgQuery::Deparse do
       end
 
       context 'Subselect in FROM clause' do
-        let(:query) { "SELECT * FROM (SELECT generate_series(0, 100)) a" }
+        let(:query) { "SELECT * FROM (SELECT generate_series(0, 100)) \"a\"" }
 
         it { is_expected.to eq query }
       end
@@ -299,7 +299,7 @@ describe PgQuery::Deparse do
       end
 
       context 'Subselect JOIN' do
-        let(:query) { 'SELECT * FROM "x" JOIN (SELECT "n" FROM "z") b ON "a"."id" = "b"."id"' }
+        let(:query) { 'SELECT * FROM "x" JOIN (SELECT "n" FROM "z") "b" ON "a"."id" = "b"."id"' }
 
         it { is_expected.to eq query }
       end
@@ -413,7 +413,7 @@ describe PgQuery::Deparse do
       end
 
       context 'NULLIF' do
-        let(:query) { 'SELECT NULLIF("id", 0) AS id FROM "x"' }
+        let(:query) { 'SELECT NULLIF("id", 0) AS "id" FROM "x"' }
 
         it { is_expected.to eq query }
       end
@@ -479,7 +479,7 @@ describe PgQuery::Deparse do
           SELECT * FROM crosstab(
           'SELECT "department", "role", COUNT("id") FROM "users" GROUP BY "department", "role" ORDER BY "department", "role"',
           'VALUES (''admin''::text), (''ordinary''::text)')
-          ctab (department varchar, admin int, ordinary int)
+          "ctab" (department varchar, admin int, ordinary int)
           }
         end
 
@@ -489,8 +489,8 @@ describe PgQuery::Deparse do
       context 'with columndef list returning an array' do
         let(:query) do
           %q{
-          SELECT "row_cols"[0] AS dept, "row_cols"[1] AS sub, "admin", "ordinary" FROM crosstab(
-          'SELECT ARRAY["department", "sub"] AS row_cols, "role", COUNT("id") FROM "users" GROUP BY "department", "role" ORDER BY "department", "role"',
+          SELECT "row_cols"[0] AS "dept", "row_cols"[1] AS "sub", "admin", "ordinary" FROM crosstab(
+          'SELECT ARRAY["department", "sub"] AS "row_cols", "role", COUNT("id") FROM "users" GROUP BY "department", "role" ORDER BY "department", "role"',
           'VALUES (''admin''::text), (''ordinary''::text)')
           AS (row_cols varchar[], admin int, ordinary int)
           }
@@ -635,7 +635,7 @@ describe PgQuery::Deparse do
 
       context 'elaborate' do
         let(:query) do
-          'UPDATE ONLY "x" table_x SET y = 1 WHERE "z" = \'abc\' RETURNING "y" AS changed_y'
+          'UPDATE ONLY "x" "table_x" SET y = 1 WHERE "z" = \'abc\' RETURNING "y" AS "changed_y"'
         end
 
         it { is_expected.to eq query }
@@ -688,7 +688,7 @@ describe PgQuery::Deparse do
       end
 
       context 'elaborate' do
-        let(:query) { 'DELETE FROM ONLY "x" table_x USING "table_z" WHERE "y" = 1 RETURNING *' }
+        let(:query) { 'DELETE FROM ONLY "x" "table_x" USING "table_z" WHERE "y" = 1 RETURNING *' }
 
         it { is_expected.to eq query }
       end
@@ -1204,8 +1204,8 @@ describe PgQuery::Deparse do
     context 'for single query' do
       let(:query) do
         '''
-        SELECT "m"."name" AS mname, "pname"
-          FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true
+        SELECT "m"."name" AS "mname", "pname"
+          FROM "manufacturers" "m" LEFT JOIN LATERAL get_product_names("m"."id") "pname" ON true
         '''
       end
 
@@ -1215,8 +1215,8 @@ describe PgQuery::Deparse do
     context 'for multiple queries' do
       let(:query) do
         '''
-        SELECT "m"."name" AS mname, "pname"
-          FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true;
+        SELECT "m"."name" AS "mname", "pname"
+          FROM "manufacturers" "m" LEFT JOIN LATERAL get_product_names("m"."id") "pname" ON true;
         INSERT INTO "manufacturers_daily" (a, b)
           SELECT "a", "b" FROM "manufacturers";
         '''
@@ -1228,8 +1228,8 @@ describe PgQuery::Deparse do
     context 'for multiple queries with a semicolon inside a value' do
       let(:query) do
         '''
-        SELECT "m"."name" AS mname, "pname"
-          FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true;
+        SELECT "m"."name" AS "mname", "pname"
+          FROM "manufacturers" "m" LEFT JOIN LATERAL get_product_names("m"."id") "pname" ON true;
         UPDATE "users" SET name = \'bobby; drop tables\';
         INSERT INTO "manufacturers_daily" (a, b)
           SELECT "a", "b" FROM "manufacturers";

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -334,6 +334,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'ALL' do
+        let(:query) { 'SELECT * FROM "x" WHERE "x" = ALL(?)' }
+
+        it { is_expected.to eq query }
+      end
+
       context 'ANY' do
         let(:query) { 'SELECT * FROM "x" WHERE "x" = ANY(?)' }
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -772,6 +772,40 @@ describe PgQuery::Deparse do
       end
     end
 
+    context 'CREATE SCHEMA' do
+      # Taken from https://www.postgresql.org/docs/11/sql-createschema.html
+      context 'basic' do
+        let(:query) { 'CREATE SCHEMA "myschema"' }
+
+        it { is_expected.to eq query }
+      end
+
+      context 'with authorization' do
+        let(:query) { 'CREATE SCHEMA AUTHORIZATION "joe"' }
+
+        it { is_expected.to eq query }
+      end
+
+      context 'with if not exist' do
+        let(:query) { 'CREATE SCHEMA IF NOT EXISTS "test" AUTHORIZATION "joe"' }
+
+        it { is_expected.to eq query }
+      end
+
+      context 'with cschema_element' do
+        let(:query) do
+          """
+          CREATE SCHEMA \"hollywood\"
+          CREATE TABLE \"films\" (title text, release date, awards text[])
+          CREATE VIEW winners AS
+              SELECT \"title\", \"release\" FROM \"films\" WHERE \"awards\" IS NOT NULL
+          """.strip
+        end
+
+        it { is_expected.to eq oneline_query }
+      end
+    end
+
     context 'CREATE TABLE' do
       context 'top-level' do
         let(:query) do

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -80,6 +80,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'EXCEPT' do
+        let(:query) { "SELECT \"a\" FROM \"kodsis\" EXCEPT SELECT \"a\" FROM \"application\"" }
+
+        it { is_expected.to eq query }
+      end
+
       context 'with specific column alias' do
         let(:query) { "SELECT * FROM (VALUES ('anne', 'smith'), ('bob', 'jones'), ('joe', 'blow')) names(\"first\", \"last\")" }
 


### PR DESCRIPTION
**Added ALL operator for deparse and unit tests.** 

SELECT id FROM kodsis WHERE id > ALL(SELECT id FROM kodsis_sub);
OR 
SELECT id FROM kodsis WHERE id > ALL(ARRAY[1,2,3,4,5]);

in addition to:
Solution for #132

**UNION or UNION ALL deparse problem.(use with ORDER,WITH like)**

SELECT 1 UNION select 2 ORDER BY 1 DESC;
OR
WITH kodsis AS (SELECT * FROM application), kodsis2 AS (SELECT * FROM application) SELECT * FROM kodsis UNION SELECT * FROM kodsis ORDER BY id DESC;

in addition to:
Solution for #129


**EXCEPT deparse problem.**

SELECT "a" FROM "kodsis" EXCEPT SELECT "a" FROM "application"

in addition to:
Solution for #125

**Problem when deparsing query with renamend Columns**

SELECT "Test"."id" as "new Test Id" from "student" "Test"

in addition to:
Solution for #128

**Problem when deparsing empty array query** 

select array[]::text[] from x

in addition to:
Solution for #124


**Deparse CREATE SCHEMA**

CREATE SCHEMA myschema;
OR
CREATE SCHEMA AUTHORIZATION joe;
OR
CREATE SCHEMA IF NOT EXISTS test AUTHORIZATION joe;
OR
CREATE SCHEMA hollywood
    CREATE TABLE films (title text, release date, awards text[])
    CREATE VIEW winners AS
        SELECT title, release FROM films WHERE awards IS NOT NULL;
        
in addition to:
Solution for #122


**Deparse CREATE CAST**

CREATE CAST (bigint AS int4) WITH FUNCTION int4(bigint) AS ASSIGNMENT;

CREATE CAST (bigint AS int4) WITHOUT FUNCTION AS IMPLICIT;

CREATE CAST (bigint AS int4) WITH INOUT AS ASSIGNMENT;
