### PR TITLE
Add deparse support for named window functions

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -374,12 +374,14 @@ class PgQuery
       name = (node['funcname'].map { |n| deparse_item(n, FUNC_CALL) } - ['pg_catalog']).join('.')
       distinct = node['agg_distinct'] ? 'DISTINCT ' : ''
       output << format('%s(%s%s)', name, distinct, args.join(', '))
-      output << format('OVER (%s)', deparse_item(node['over'])) if node['over']
+      output << format('OVER %s', deparse_item(node['over'])) if node['over']
 
       output.join(' ')
     end
 
     def deparse_windowdef(node)
+      return deparse_identifier(node['name']) if node['name']
+
       output = []
 
       if node['partitionClause']
@@ -396,7 +398,7 @@ class PgQuery
         end.join(', ')
       end
 
-      output.join(' ')
+      format('(%s)', output.join(' '))
     end
 
     def deparse_functionparameter(node)

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -1088,6 +1088,12 @@ describe PgQuery::Deparse do
 
         it { is_expected.to eq query }
       end
+
+      context 'OVER with named window' do
+        let(:query) { 'SELECT rank(*) OVER named_window' }
+
+        it { is_expected.to eq query }
+      end
     end
 
     context 'VIEWS' do


### PR DESCRIPTION
Postgres window functions support a variant where the target list can reference a named window e.g.

```sql
SELECT rank() OVER team_window
FROM people
WINDOW team_window AS (
  PARTITION BY people.team_id
)
```