### PR TITLE
Add support for INSERT INTO ... RETURNING

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1121,6 +1121,13 @@ class PgQuery
 
       output << deparse_item(node['selectStmt'])
 
+      if node['returningList']
+        output << 'RETURNING'
+        output << node['returningList'].map do |column|
+          deparse_item(column['ResTarget']['val'])
+        end.join(', ')
+      end
+
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -102,6 +102,8 @@ class PgQuery
         deparse_copy(node)
       when CREATE_CAST_STMT
         deparse_create_cast(node)
+      when CREATE_DOMAIN_STMT
+        deparse_create_domain(node)
       when CREATE_ENUM_STMT
         deparse_create_enum(node)
       when CREATE_FUNCTION_STMT
@@ -801,6 +803,7 @@ class PgQuery
       if node['raw_expr']
         expression = deparse_item(node['raw_expr'])
         # Unless it's simple, put parentheses around it
+        expression = '(' + expression + ')' if node['raw_expr'][BOOL_EXPR]
         expression = '(' + expression + ')' if node['raw_expr'][A_EXPR] && node['raw_expr'][A_EXPR]['kind'] == AEXPR_OP
         output << expression
       end
@@ -859,6 +862,18 @@ class PgQuery
                 end
       output << 'AS IMPLICIT' if (node['context']).zero?
       output << 'AS ASSIGNMENT' if node['context'] == 1
+      output.join(' ')
+    end
+
+    def deparse_create_domain(node)
+      output = []
+      output << 'CREATE'
+      output << 'DOMAIN'
+      output << deparse_item_list(node['domainname']).join('.')
+      output << 'AS'
+      output << deparse_item(node['typeName']) if node['typeName']
+      output << deparse_item(node['collClause']) if node['collClause']
+      output << deparse_item_list(node['constraints'])
       output.join(' ')
     end
 

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1124,7 +1124,7 @@ class PgQuery
       if node['returningList']
         output << 'RETURNING'
         output << node['returningList'].map do |column|
-          deparse_item(column['ResTarget']['val'])
+          deparse_item(column, :select)
         end.join(', ')
       end
 

--- a/lib/pg_query/node_types.rb
+++ b/lib/pg_query/node_types.rb
@@ -28,6 +28,7 @@ class PgQuery
   CONSTRAINT = 'Constraint'.freeze
   COPY_STMT = 'CopyStmt'.freeze
   CREATE_CAST_STMT = 'CreateCastStmt'.freeze
+  CREATE_DOMAIN_STMT = 'CreateDomainStmt'.freeze
   CREATE_ENUM_STMT = 'CreateEnumStmt'.freeze
   CREATE_FUNCTION_STMT = 'CreateFunctionStmt'.freeze
   CREATE_RANGE_STMT = 'CreateRangeStmt'.freeze

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -745,6 +745,22 @@ describe PgQuery::Deparse do
       end
     end
 
+    context 'CREATE DOMAIN' do
+      context 'with check' do
+        let(:query) do
+          """
+          CREATE DOMAIN \"us_postal_code\" AS text
+          CHECK (
+             \"VALUE\" ~ '^\d{5}$'
+          OR \"VALUE\" ~ '^\d{5}-\d{4}$'
+          );
+          """.strip
+        end
+
+        it { is_expected.to eq oneline_query }
+      end
+    end
+
     context 'CREATE FUNCTION' do
       # Taken from http://www.postgresql.org/docs/8.3/static/queries-table-expressions.html
       context 'with inline function definition' do

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -541,6 +541,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'with RETURNING' do
+        let(:query) { 'INSERT INTO "x" (y, z) VALUES (1, \'abc\') RETURNING "id"' }
+
+        it { is_expected.to eq query }
+      end
+
       context 'INTO SELECT' do
         let(:query) { 'INSERT INTO "x" SELECT * FROM "y"' }
 


### PR DESCRIPTION
SQL:
INSERT INTO "x" (y, z) VALUES (1, \'abc\') RETURNING "id"

Deparser Result:
INSERT INTO "x" (y, z) VALUES (1, \'abc\')

After Fix:
INSERT INTO "x" (y, z) VALUES (1, \'abc\') RETURNING "id"