### PR TITLE
Subquery indirection

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -282,7 +282,7 @@ class PgQuery
     def deparse_a_indirection(node)
       output = []
       arg = deparse_item(node['arg'])
-      output << if node['arg'].key?(FUNC_CALL)
+      output << if node['arg'].key?(FUNC_CALL) || node['arg'].key?(SUB_LINK)
                   "(#{arg})."
                 else
                   arg

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -316,6 +316,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'sub query indirection' do
+        let(:query) { "SELECT COALESCE(((SELECT customer.sp_person(\"n\".\"id\") AS sp_person)).\"city_id\", NULL::int) AS city_id FROM \"customer\".\"tb_customer\" n" }
+
+        it { is_expected.to eq query }
+      end
+
       context 'complex indirection' do
         let(:query) { 'SELECT * FROM "x" WHERE "y" = "z"[?][?]' }
 


### PR DESCRIPTION
SELECT COALESCE(((SELECT customer.sp_person(\"n\".\"id\") AS sp_person)).\"city_id\", NULL::int) AS city_id FROM \"customer\".\"tb_customer\" n