### PR TITLE
Array indirection problem fixed.

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -308,7 +308,11 @@ class PgQuery
     def deparse_a_indirection(node)
       output = []
       arg = deparse_item(node['arg'])
-      output << if node['arg'].key?(FUNC_CALL) || node['arg'].key?(SUB_LINK)
+      array_indirection = []
+      if node['indirection']
+        array_indirection = node['indirection'].select { |a| a.key?(A_INDICES) }
+      end
+      output << if node['arg'].key?(FUNC_CALL) || (node['arg'].key?(SUB_LINK) && array_indirection.count.zero?)
                   "(#{arg})."
                 else
                   arg

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -312,7 +312,7 @@ class PgQuery
       if node['indirection']
         array_indirection = node['indirection'].select { |a| a.key?(A_INDICES) }
       end
-      output << if node['arg'].key?(FUNC_CALL) || (node['arg'].key?(SUB_LINK) && array_indirection.count.zero?)
+      output << if node['arg'].key?(FUNC_CALL) || node['arg'].key?(A_EXPR) || (node['arg'].key?(SUB_LINK) && array_indirection.count.zero?)
                   "(#{arg})."
                 else
                   arg

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -352,6 +352,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'indirection with star' do
+        let(:query) { 'SELECT ("k" #= hstore(\'{id}\'::text[], ARRAY[1::text])).* FROM "test" k' }
+
+        it { is_expected.to eq query }
+      end
+
       context 'NOT' do
         let(:query) { 'SELECT * FROM "x" WHERE NOT "y"' }
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -334,6 +334,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'array indirection' do
+        let(:query) { "SELECT \"proname\", (SELECT regexp_split_to_array(\"proargtypes\"::text, ' ') )[\"idx\"] AS argtype, \"proargnames\"[\"idx\"] AS argname FROM \"pg_proc\"" }
+
+        it { is_expected.to eq oneline_query }
+      end
+
       context 'sub query indirection' do
         let(:query) { "SELECT COALESCE(((SELECT customer.sp_person(\"n\".\"id\") AS sp_person)).\"city_id\", NULL::int) AS city_id FROM \"customer\".\"tb_customer\" n" }
 


### PR DESCRIPTION
SQL: SELECT  "proname", (SELECT regexp_split_to_array( "proargtypes"::text, ' ') )[ "idx"] AS argtype,  "proargnames "[ "idx"] AS argname FROM  "pg_proc"

Expected: SELECT  "proname", (SELECT regexp_split_to_array( "proargtypes"::text, ' ') )[ "idx"] AS argtype,  "proargnames "[ "idx"] AS argname FROM  "pg_proc"

Got: SELECT  "proname", (SELECT regexp_split_to_array( "proargtypes"::text, ' ') ).[ "idx"] AS argtype,  "proargnames "[ "idx"] AS argname FROM  "pg_proc"