### PR TITLE
Array function problem fixed.

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1040,6 +1040,8 @@ class PgQuery
         format('%s %s ALL (%s)', deparse_item(node['testexpr']), deparse_item(node['operName'][0], :operator), deparse_item(node['subselect']))
       elsif node['subLinkType'] == SUBLINK_TYPE_EXISTS
         format('EXISTS(%s)', deparse_item(node['subselect']))
+      elsif node['subLinkType'] == SUBLINK_TYPE_ARRAY
+        format('ARRAY(%s)', deparse_item(node['subselect']))
       else
         format('(%s)', deparse_item(node['subselect']))
       end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -169,6 +169,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'ARRAY' do
+        let(:query) { 'SELECT ARRAY(SELECT "id" FROM "products")::bigint[]' }
+
+        it { is_expected.to eq query }
+      end
+
       context 'LATERAL' do
         let(:query) { 'SELECT "m"."name" AS mname, "pname" FROM "manufacturers" m, LATERAL get_product_names("m"."id") pname' }
 


### PR DESCRIPTION
SQL: SELECT ARRAY(SELECT "id" FROM "products")::bigint[]

Expected: SELECT ARRAY(SELECT "id" FROM "products")::bigint[]

Got: SELECT (SELECT "id" FROM "products")::bigint[]