### PR TITLE
Lateral problem

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -1046,7 +1046,9 @@ class PgQuery
     end
 
     def deparse_rangesubselect(node)
-      output = '(' + deparse_item(node['subquery']) + ')'
+      output = ''
+      output = 'LATERAL ' if node['lateral']
+      output = output + '(' + deparse_item(node['subquery']) + ')'
       if node['alias']
         output + ' ' + deparse_item(node['alias'])
       else

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -169,22 +169,6 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
-      context 'LATERAL JOIN 2' do
-        let(:query) do
-          %(
-          SELECT *
-                  FROM "tb_test_main" mh
-                  JOIN LATERAL (
-                    SELECT "ftnrm".* FROM "test" ftnrm WHERE "ftnrm"."hizmet_id" = "mh"."id"
-                    UNION ALL
-                    SELECT "ftarc".* FROM "test"."test2" ftarc WHERE "ftarc"."hizmet_id" = "mh"."id"
-                  ) ft ON true
-          )
-        end
-
-        it { is_expected.to eq oneline_query }
-      end
-
       context 'LATERAL' do
         let(:query) { 'SELECT "m"."name" AS mname, "pname" FROM "manufacturers" m, LATERAL get_product_names("m"."id") pname' }
 
@@ -196,6 +180,22 @@ describe PgQuery::Deparse do
           %(
           SELECT "m"."name" AS mname, "pname"
             FROM "manufacturers" m LEFT JOIN LATERAL get_product_names("m"."id") pname ON true
+          )
+        end
+
+        it { is_expected.to eq oneline_query }
+      end
+
+      context 'LATERAL JOIN with sql' do
+        let(:query) do
+          %(
+          SELECT *
+                  FROM "tb_test_main" mh
+                  JOIN LATERAL (
+                    SELECT "ftnrm".* FROM "test" ftnrm WHERE "ftnrm"."hizmet_id" = "mh"."id"
+                    UNION ALL
+                    SELECT "ftarc".* FROM "test"."test2" ftarc WHERE "ftarc"."hizmet_id" = "mh"."id"
+                  ) ft ON true
           )
         end
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -169,6 +169,22 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'LATERAL JOIN 2' do
+        let(:query) do
+          %(
+          SELECT *
+                  FROM "tb_test_main" mh
+                  JOIN LATERAL (
+                    SELECT "ftnrm".* FROM "test" ftnrm WHERE "ftnrm"."hizmet_id" = "mh"."id"
+                    UNION ALL
+                    SELECT "ftarc".* FROM "test"."test2" ftarc WHERE "ftarc"."hizmet_id" = "mh"."id"
+                  ) ft ON true
+          )
+        end
+
+        it { is_expected.to eq oneline_query }
+      end
+
       context 'LATERAL' do
         let(:query) { 'SELECT "m"."name" AS mname, "pname" FROM "manufacturers" m, LATERAL get_product_names("m"."id") pname' }
 


### PR DESCRIPTION
LATERAL JOIN problem

expected: SELECT *
                            FROM "tb_test_main" mh
                            _**JOIN LATERAL**_ (
                              SELECT "ftnrm".* FROM "test" ftnrm WHERE "ftnrm"."hizmet_id" = "mh"."id"
                              UNION ALL
                              SELECT "ftarc".* FROM "test"."test2" ftarc WHERE "ftarc"."hizmet_id" = "mh"."id"
                            ) ft ON true
                    )
                
got: SELECT *
                       FROM "tb_test_main" mh
                       **_JOIN_** (
                         SELECT "ftnrm".* FROM "test" ftnrm WHERE "ftnrm"."hizmet_id" = "mh"."id"
                         UNION ALL
                         SELECT "ftarc".* FROM "test"."test2" ftarc WHERE "ftarc"."hizmet_id" = "mh"."id"
                       ) ft ON true
               )