### PR TITLE
Find tables in the subquery of CREATE TABLE AS

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -124,6 +124,9 @@ class PgQuery
           if statement[CREATE_TABLE_AS_STMT]['into'] && statement[CREATE_TABLE_AS_STMT]['into'][INTO_CLAUSE]['rel']
             from_clause_items << { item: statement[CREATE_TABLE_AS_STMT]['into'][INTO_CLAUSE]['rel'], type: :ddl }
           end
+          if statement[CREATE_TABLE_AS_STMT]['query']
+            from_clause_items << { item: statement[CREATE_TABLE_AS_STMT]['query'], type: :select }
+          end
         when TRUNCATE_STMT
           from_clause_items += statement.values[0]['relations'].map { |r| { item: r, type: :ddl } }
         when VIEW_STMT

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -125,7 +125,7 @@ class PgQuery
             from_clause_items << { item: statement[CREATE_TABLE_AS_STMT]['into'][INTO_CLAUSE]['rel'], type: :ddl }
           end
           if statement[CREATE_TABLE_AS_STMT]['query']
-            from_clause_items << { item: statement[CREATE_TABLE_AS_STMT]['query'], type: :select }
+            statements << statement[CREATE_TABLE_AS_STMT]['query']
           end
         when TRUNCATE_STMT
           from_clause_items += statement.values[0]['relations'].map { |r| { item: r, type: :ddl } }

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -931,4 +931,16 @@ $BODY$
              'defaction' => 0,
              'location' => 44 } }] } }}}]
   end
+
+  describe 'parsing CREATE TABLE AS' do
+    it 'finds tables in the subquery' do
+      query = described_class.parse(<<-SQL)
+        CREATE TABLE foo AS
+          SELECT * FROM bar;
+      SQL
+      expect(query.tables).to eq(['foo', 'bar'])
+      expect(query.ddl_tables).to eq(['foo'])
+      expect(query.select_tables).to eq(['bar'])
+    end
+  end
 end

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -942,5 +942,16 @@ $BODY$
       expect(query.ddl_tables).to eq(['foo'])
       expect(query.select_tables).to eq(['bar'])
     end
+
+    it 'finds tables in the subquery with UNION' do
+      query = described_class.parse(<<-SQL)
+        CREATE TABLE foo AS
+          SELECT id FROM bar UNION SELECT id from baz;
+      SQL
+
+      expect(query.tables).to eq(['foo', 'bar', 'baz'])
+      expect(query.ddl_tables).to eq(['foo'])
+      expect(query.select_tables).to eq(['bar', 'baz'])
+    end
   end
 end


### PR DESCRIPTION
## Problem
Tables in the subselect of `CREATE TABLE .. AS` statements are not included in the `*tables` methods.

### Example:
`PgQuery.parse("CREATE TABLE foo AS SELECT * FROM bar").tables`
Expected: `["foo", "bar"]`
Actual: `["foo"]`
