### PR TITLE
fix undefined local variable or method `expected_sha256'

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -23,7 +23,7 @@ unless File.exist?(filename)
   checksum = Digest::SHA256.hexdigest(File.read(filename))
 
   if checksum != LIB_PG_QUERY_SHA256SUM
-    raise "SHA256 of #{filename} does not match: got #{checksum}, expected #{expected_sha256}"
+    raise "SHA256 of #{filename} does not match: got #{checksum}, expected #{LIB_PG_QUERY_SHA256SUM}"
   end
 end
 


### PR DESCRIPTION
From 
https://github.com/lfittl/pg_query/commit/064472a12e9dd623fa085162681325cc8eeb9d84#diff-8e5f1c8bbc2ab74598f30b99a2798a7354372f46a4340bfa93815cd615825e30 changes, forgot change this variable name