### PR TITLE
Support null_test and boolean_test node type with parsing

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -276,10 +276,14 @@ module PgQuery
             end
           when :bool_expr
             subselect_items.concat(next_item.bool_expr.args.to_ary)
+          when :boolean_test
+            subselect_items << next_item.boolean_test.arg
           when :coalesce_expr
             subselect_items.concat(next_item.coalesce_expr.args.to_ary)
           when :min_max_expr
             subselect_items.concat(next_item.min_max_expr.args.to_ary)
+          when :null_test
+            subselect_items << next_item.null_test.arg
           when :res_target
             subselect_items << next_item.res_target.val
           when :sub_link
@@ -296,8 +300,6 @@ module PgQuery
             subselect_items << next_item.case_expr.defresult
           when :type_cast
             subselect_items << next_item.type_cast.arg
-          when :null_test
-            subselect_items << next_item.null_test.arg
           end
         end
 

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -296,6 +296,8 @@ module PgQuery
             subselect_items << next_item.case_expr.defresult
           when :type_cast
             subselect_items << next_item.type_cast.arg
+          when :null_test
+            subselect_items << next_item.null_test.arg
           end
         end
 

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -1639,6 +1639,14 @@ $BODY$
     expect(query.call_functions).to eq ['f1']
   end
 
+  it 'finds the table in boolean_test' do
+    query = described_class.parse(<<-SQL)
+      SELECT col1 FROM t1 WHERE (SELECT col2 FROM t2 LIMIT 1) IS TRUE;
+    SQL
+    expect(query.tables).to eq(['t1', 't2'])
+    expect(query.select_tables).to eq(['t1', 't2'])
+  end
+
   describe 'parsing INSERT' do
     it 'finds the table inserted into' do
       query = described_class.parse(<<-SQL)

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -1627,6 +1627,18 @@ $BODY$
     expect(query.select_tables).to eq(['films'])
   end
 
+  it 'finds tables and functions inside subselects in null_test' do
+    query = described_class.parse(<<-SQL)
+      SELECT col1 FROM t1 WHERE ((SELECT col2 FROM t2 LIMIT 1) IS NULL) AND ((SELECT * FROM f1() LIMIT 1) IS NULL);
+    SQL
+    expect(query.tables).to eq(['t1', 't2'])
+    expect(query.select_tables).to eq(['t1', 't2'])
+    expect(query.dml_tables).to eq([])
+    expect(query.ddl_tables).to eq([])
+    expect(query.ddl_functions).to eq []
+    expect(query.call_functions).to eq ['f1']
+  end
+
   describe 'parsing INSERT' do
     it 'finds the table inserted into' do
       query = described_class.parse(<<-SQL)


### PR DESCRIPTION
When the query like `SELECT col1 FROM t1 WHERE ((SELECT col2 FROM t2 LIMIT 1) IS NULL)` is passed, the subselect_items contain the item with the null_test node type.
This null_test node type could contain a table name or a function potentially, but that node type is ignored currently, therefore these table names or functions weren't properly extracted as tables/functions of the query.
With this change, by adding the argument of null_test node to the subselect_items list, the arg will be evaluated again later on and will be properly handled.